### PR TITLE
Set up local SMTP

### DIFF
--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -178,5 +178,15 @@ if os.getenv("DATABASE_URL"):
     }
 
 
+# Set up SMTP
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
+#: The host to use for sending email.
+EMAIL_HOST = os.getenv("SMTP_HOST", "mail")
+
+#: Port to use for the SMTP server defined in EMAIL_HOST.
+EMAIL_PORT = os.getenv("SMTP_PORT", 25)
+
+
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)

--- a/signbank/settings/development.py
+++ b/signbank/settings/development.py
@@ -44,9 +44,6 @@ MEDIA_URL = '/media/'
 UPLOAD_ROOT = MEDIA_ROOT + 'upload/'
 UPLOAD_URL = MEDIA_URL + 'upload/'
 
-#: To test emailing, use this to show emails in the console
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
This pull request configures SMTP to use Maildev in development and production, with the SMTP_HOST and SMTP_PORT configurable via environment variables. It's likely we'll need to add additional variables to run in Heroku, but for now this provides the minimal configuration to use a local SMTP server for testing email deliverability.

Send a test email via `docker-compose run backend python3 ./bin/develop.py sendtestemail test@example.com`. The email is received:

<img width="1367" alt="image" src="https://user-images.githubusercontent.com/292020/166640261-a1c9ccd2-956a-4f92-8159-8970b40dd3a7.png">
