### PR TITLE
Remove urlencode from video and poster URLs

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -189,7 +189,7 @@ $('#id_comment').atwho({
                             </div>
                             <div class="embed-responsive embed-responsive-16by9">
                                 <video id="glossvideo-{{glossvideo.pk}}" class="embed-responsive-item" width="450" preload="metadata" controls muted
-                                       {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url|urlencode}}"{% endif %}>
+                                       {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
                                     {% if glossvideo.get_extension == '.mp4' %}
                                     <source src="{{glossvideo.videofile.url}}" type="video/mp4">
                                     {% elif glossvideo.get_extension == '.webm' %}

--- a/signbank/dictionary/templates/dictionary/public_gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_detail.html
@@ -90,11 +90,11 @@
                 </header>
                 <div class="embed-responsive embed-responsive-16by9">
                     <video id="glossvideo-{{glossvideo.pk}}" preload="metadata" controls muted
-                    {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url|urlencode}}"{% endif %}>
+                    {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
                     {% if glossvideo.get_extension == '.mp4' %}
-                        <source src="{{glossvideo.videofile.url|urlencode}}" type="video/mp4">
+                        <source src="{{glossvideo.videofile.url}}" type="video/mp4">
                     {% elif glossvideo.get_extension == '.webm' %}
-                        <source src="{{glossvideo.videofile.url|urlencode}}" type="video/webm">
+                        <source src="{{glossvideo.videofile.url}}" type="video/webm">
                     {% endif %}
                         {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
                     </video>

--- a/signbank/dictionary/templates/dictionary/public_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_list.html
@@ -167,12 +167,12 @@ $( document ).ready(function() {
                  {% if obj.glossvideo_set.all.count > 0 %}style="background-color:rgb(33,33,33);"{% endif %}>
             {% if obj.glossvideo_set.all.0 %}
                 <video id="glossvideo-{{obj.glossvideo_set.all.0.pk}}" class="video-public" preload="metadata" muted
-{% if obj.glossvideo_set.all.0.posterfile %} poster="{{obj.glossvideo_set.all.0.posterfile.url|urlencode}}"{% endif %}
+{% if obj.glossvideo_set.all.0.posterfile %} poster="{{obj.glossvideo_set.all.0.posterfile.url}}"{% endif %}
                 onclick="this.paused?this.play():this.pause();" playsinline>
                 {% if obj.glossvideo_set.all.0.get_extension == '.mp4' %}
-                    <source src="{{obj.glossvideo_set.all.0.videofile.url|urlencode}}" type="video/mp4">
+                    <source src="{{obj.glossvideo_set.all.0.videofile.url}}" type="video/mp4">
                 {% elif obj.glossvideo_set.all.0.get_extension == '.webm' %}
-                    <source src="{{obj.glossvideo_set.all.0.videofile.url|urlencode}}" type="video/webm">
+                    <source src="{{obj.glossvideo_set.all.0.videofile.url}}" type="video/webm">
                 {% endif %}
                     {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
                 </video>

--- a/signbank/video/templates/uploaded_glossvideos.html
+++ b/signbank/video/templates/uploaded_glossvideos.html
@@ -48,9 +48,9 @@
                     <div class="player">
                         <video id="{{video.pk}}" width="450" preload="metadata" controls muted>
                             {% if video.get_extension == '.mp4' %}
-                            <source src="{{video.videofile.url|urlencode}}" type="video/mp4">
+                            <source src="{{video.videofile.url}}" type="video/mp4">
                             {% elif video.get_extension == '.webm' %}
-                            <source src="{{video.videofile.url|urlencode}}" type="video/webm">
+                            <source src="{{video.videofile.url}}" type="video/webm">
                             {% endif %}
                             {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
                         </video>


### PR DESCRIPTION
This may be needed for file-based serving (I actually doubt it since django's URL building for files should take care of this, but this URL-encodes AWS S3 URLs and stops these from working, so need to be removed.

After patch:

![image](https://user-images.githubusercontent.com/292020/168502655-a8e15ee8-85a1-41fe-b368-93a9d9245dd9.png)
