### PR TITLE
N2-78: Don't show comments on the public gloss page

### DIFF
--- a/signbank/dictionary/templates/dictionary/public_gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_detail.html
@@ -168,44 +168,6 @@
         </section>
     </div>
 </div>
-<div class="row">
-    <div class="col-md-10 col-md-offset-1">
-        <hr style="border-color:black;">
-        {% get_comment_count for gloss as comment_count %}
-        <div id="gloss-comments">
-            <aside>
-                <header>
-                    <a class="btn btn-primary" role="button" data-toggle="collapse" href="#collapse-comments"
-                    aria-expanded="false" aria-controls="collapse-comments">
-                        <h4>{% blocktrans %}Show comments{% endblocktrans %} ({{comment_count}})</h4>
-                    </a>
-                </header>
-                <div class="collapse" id="collapse-comments">
-                    <div class="well well-md">
-                    {% get_comment_list for gloss as comment_list %}
-                    {% for comment in comment_list %}
-                        {% tags_for_object comment as tag_list %}
-                        <article class="comment">
-                            <header id="c{{ comment.id }}">
-                                <strong>{{ comment.submit_date }} -
-                                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{ comment.name }}</strong>
-                            {% for tag in tag_list %}
-                                <div class="comment-tags" style="display:inline;">
-                                    <span class="label label-info">{{tag}}</span>
-                                </div>
-                            {% endfor %}
-                            </header>
-                            <p>{{ comment.comment }}</p>
-                        </article>
-                    {% empty %}
-                        <p><em>{% blocktrans %}No comments.{% endblocktrans %}</em></p>
-                    {% endfor %}
-                    </div>
-                </div>
-            </aside>
-        </div>
-    </div>
-</div>
 </article>
 </div>
 {% endblock %}


### PR DESCRIPTION
This pull request removes the comments section from the public gloss detail page. Other pages that have comments, like the advanced gloss screen, admin area require login. The homepage shows recent comments, but only for logged-in users. 

![image](https://user-images.githubusercontent.com/292020/168937623-4addbe5e-a9fe-430f-a19e-9420ea043117.png)

![image](https://user-images.githubusercontent.com/292020/168937698-c384a0f3-8bf1-4ad4-8710-9c547eb8688b.png)
