### PR TITLE
Adding concise to advanced gloss

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -410,6 +410,10 @@ $('#id_comment').atwho({
                     <th>{% blocktrans %}Film batch:{% endblocktrans %}</th>
                     <td class="edit edit_text" id='filmbatch'>{{gloss.filmbatch}}</td>
                 </tr>
+                <tr>
+                    <th>{% blocktrans %}Concise:{% endblocktrans %}</th>
+                    <td id="concise">{{ gloss.concise }}</td>
+                </tr>
                 {# Translators: Information about a Gloss #}
                 <!-- {# Removed Dialect for now, uncomment these lines if you want to show dialect #}
                 <tr>


### PR DESCRIPTION
JIRA Ticket: https://ackama.atlassian.net/browse/N2-69

This ticket is to add `concise` to django admin and `advanced/gloss` pages. This field is not editable as per the discussion in JIRA ticket.

django admin:
![Screenshot from 2022-06-07 15-24-43](https://user-images.githubusercontent.com/5234605/172303304-5a788f1b-52fd-402e-b8f4-58366fa6d7a4.png)


`advanced/gloss`:
![Screenshot from 2022-06-07 15-24-43](https://user-images.githubusercontent.com/5234605/172303170-0c57ba4b-fde0-4463-89cc-f639f908e8a3.png)