### PR TITLE
N2-27: Display images that are uploaded to GlossVideo models

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -197,7 +197,7 @@ function clearForm(myFormElement) {
             <td><a href="{% url 'dictionary:admin_gloss_view' pk=gloss.pk %}"
                    data-thumbnail-src="{% if gloss.glossvideo_set.all.0.posterfile %}{{gloss.glossvideo_set.all.0.posterfile.url}}{% endif %}"
                    data-video-src="{% if gloss.glossvideo_set.all.0.videofile %}{{ gloss.glossvideo_set.all.0.videofile.url }}"
-                   data-video-ext="{{ gloss.glossvideo_set.all.0.get_extension|slice:"1:" }}{% endif %}">{{ gloss.idgloss }}</a>
+                   data-content-type="{{ gloss.glossvideo_set.all.0.get_content_type }}{% endif %}">{{ gloss.idgloss }}</a>
                 {% if gloss.glossvideo_set.count > 1 %}<span class="glyphicon glyphicon-film" aria-hidden="true"
                                                              title="{% blocktrans %}Videos{% endblocktrans %}" style="margin-left:5px;"></span>
                 <span class="sr-only">{% blocktrans context "sr-videos" %}Videos{% endblocktrans %}:</span> {{gloss.glossvideo_set.count}}{% endif %}</td>

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -35,29 +35,29 @@ function clearForm(myFormElement) {
   for(i=0; i<elements.length; i++) {
 
       field_type = elements[i].type.toLowerCase();
-    
+
       switch(field_type) {
-    
+
         case "text":
         case "password":
         case "textarea":
         case "hidden":
-    
+
           elements[i].value = "";
           break;
-    
+
         case "radio":
         case "checkbox":
             if (elements[i].checked) {
               elements[i].checked = false;
           }
           break;
-    
+
         case "select-one":
         case "select-multiple":
                     elements[i].selectedIndex = -1;
           break;
-    
+
         default:
           break;
       }

--- a/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
@@ -147,12 +147,12 @@ function clearForm(myFormElement) {
                 <a href="{% url 'dictionary:admin_gloss_view' pk=glossrelation.source.pk %}"
                    data-thumbnail-src="{% if glossrelation.source.glossvideo_set.all.0.posterfile %}{{glossrelation.source.glossvideo_set.all.0.posterfile.url}}{% endif %}"
                    data-video-src="{% if glossrelation.source.glossvideo_set.all.0.videofile %}{{ glossrelation.source.glossvideo_set.all.0.videofile.url }}"
-                   data-video-ext="{{ glossrelation.source.glossvideo_set.all.0.get_extension|slice:"1:" }}{% endif %}">{{glossrelation.source}}</a></td>
+                   data-content-type="{{ glossrelation.source.glossvideo_set.all.0.get_content_type}}{% endif %}">{{glossrelation.source}}</a></td>
             <td><span class="dataset-{{glossrelation.target.dataset.id}}-color label label-default">{{ glossrelation.target.dataset }}</span>
                 <a href="{% url 'dictionary:admin_gloss_view' pk=glossrelation.target.pk %}"
                    data-thumbnail-src="{% if glossrelation.target.glossvideo_set.all.0.posterfile %}{{glossrelation.target.glossvideo_set.all.0.posterfile.url}}{% endif %}"
                    data-video-src="{% if glossrelation.target.glossvideo_set.all.0.videofile %}{{ glossrelation.target.glossvideo_set.all.0.videofile.url }}"
-                   data-video-ext="{{ glossrelation.target.glossvideo_set.all.0.get_extension|slice:"1:" }}{% endif %}">{{glossrelation.target}}</a></td>
+                   data-content-type="{{ glossrelation.target.glossvideo_set.all.0.get_content_type}}{% endif %}">{{glossrelation.target}}</a></td>
             <td>{% for tag in glossrelation.cached_tags %}<span class='tag'>{{ tag }}</span>{% endfor %}</td>
         </tr>
     {% endfor %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -187,17 +187,17 @@ $('#id_comment').atwho({
                             <div class="video-title">
                                 <h4 class="edit edit_text" id="video_title{{glossvideo.pk}}">{{glossvideo.title}} - {{glossvideo.video_type}}</h4>
                             </div>
-                            <div class="embed-responsive embed-responsive-16by9">
-                                <video id="glossvideo-{{glossvideo.pk}}" class="embed-responsive-item" width="450" preload="metadata" controls muted
-                                       {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
-                                    {% if glossvideo.get_extension == '.mp4' %}
-                                    <source src="{{glossvideo.videofile.url}}" type="video/mp4">
-                                    {% elif glossvideo.get_extension == '.webm' %}
-                                    <source src="{{glossvideo.videofile.url}}" type="video/webm">
-                                    {% endif %}
-                                    {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
-                                </video>
-                            </div>
+                            {% if glossvideo.is_video %}
+                                <div class="embed-responsive embed-responsive-16by9">
+                                    <video id="glossvideo-{{glossvideo.pk}}" class="embed-responsive-item" width="450" preload="metadata" controls muted
+                                            {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
+                                        <source src="{{glossvideo.get_absolute_url}}" type="{{glossvideo.content_type}}">
+                                        {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
+                                    </video>
+                                </div>
+                            {% elif glossvideo.is_image %}
+                                <img src="{{glossvideo.get_absolute_url}}" alt="{{glossvideo.title}} - {{glossvideo.video_type}}" class="img-responsive center-block" />
+                            {% endif %}
                             <div class="video_edit" style="display:none;">
                                 <div class="video-ordering">
                                     <form action="{% url 'video:change_glossvideo_order' %}" method="post">{% csrf_token %}
@@ -211,7 +211,16 @@ $('#id_comment').atwho({
                                     </form>
                                 </div>
                                 <div class="poster-edit">
-                                    <button type="button" class="btn btn-success" id="vidbtn-{{glossvideo.pk}}" onclick="grabScreenshot({{glossvideo.pk}})" data-toggle="modal" data-target="#glossvideo{{glossvideo.pk}}-Modal">{% blocktrans %}Capture new poster image{% endblocktrans %}</button>
+                                    {% if glossvideo.is_video %}
+                                        <button type="button"
+                                                class="btn btn-success"
+                                                id="vidbtn-{{glossvideo.pk}}"
+                                                onclick="grabScreenshot({{glossvideo.pk}})"
+                                                data-toggle="modal"
+                                                data-target="#glossvideo{{glossvideo.pk}}-Modal">
+                                                    {% blocktrans %}Capture new poster image{% endblocktrans %}
+                                        </button>
+                                    {% endif %}
                                 </div>
                                 <form class="change-video-type" action="{% url 'video:glossvideo_update' %}" method="post">{% csrf_token %}
                                     <input type="hidden" name="glossvideo" value="{{glossvideo.pk}}">

--- a/signbank/dictionary/templates/dictionary/gloss_detail_relations.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_relations.html
@@ -12,7 +12,7 @@
             <a href="{% url 'dictionary:admin_gloss_view' gr.target.id %}"
                data-thumbnail-src="{% if gr.target.glossvideo_set.all.0.posterfile %}{{gr.target.glossvideo_set.all.0.posterfile.url}}{% endif %}"
                data-video-src="{% if gr.target.glossvideo_set.all.0.videofile %}{{ gr.target.glossvideo_set.all.0.videofile.url }}"
-               data-video-ext="{{ gr.target.glossvideo_set.all.0.get_extension|slice:"1:" }}{% endif %}">
+               data-content-type="{{ gr.target.glossvideo_set.all.0.get_content_type}}{% endif %}">
                 <span class="glyphicon glyphicon-circle-arrow-right"></span> {{gr}}</a>
             {% for tag in tag_list %}
             <span class="badge" style="float:inherit;">{{tag}}</span>
@@ -42,7 +42,7 @@
             <a href="{% url 'dictionary:admin_gloss_view' gr.source.id %}"
                data-thumbnail-src="{% if gr.source.glossvideo_set.all.0.posterfile %}{{gr.source.glossvideo_set.all.0.posterfile.url}}{% endif %}"
                data-video-src="{% if gr.source.glossvideo_set.all.0.videofile %}{{ gr.source.glossvideo_set.all.0.videofile.url }}"
-               data-video-ext="{{ gr.source.glossvideo_set.all.0.get_extension|slice:"1:" }}{% endif %}">
+               data-content-type="{{ gr.source.glossvideo_set.all.0.get_content_type}}{% endif %}">
                 <span class="glyphicon glyphicon-circle-arrow-left"></span> {{gr.source}}</a>
             {% for tag in tag_list %}
             <span class="badge" style="float:inherit;">{{tag}}</span>

--- a/signbank/dictionary/templates/dictionary/public_gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_detail.html
@@ -119,15 +119,17 @@
                     <h4>{{glossvideo.title}} - {{glossvideo.video_type}}</h4>
                 </header>
                 <div class="embed-responsive embed-responsive-16by9">
-                    <video id="glossvideo-{{glossvideo.pk}}" preload="metadata" controls muted
-                    {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
-                    {% if glossvideo.get_extension == '.mp4' %}
-                        <source src="{{glossvideo.videofile.url}}" type="video/mp4">
-                    {% elif glossvideo.get_extension == '.webm' %}
-                        <source src="{{glossvideo.videofile.url}}" type="video/webm">
+                    {% if glossvideo.is_video %}
+                        <div class="embed-responsive embed-responsive-16by9">
+                            <video id="glossvideo-{{glossvideo.pk}}" class="embed-responsive-item" preload="metadata" controls muted
+                                    {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}>
+                                <source src="{{glossvideo.get_absolute_url}}" type="{{glossvideo.content_type}}">
+                                {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
+                            </video>
+                        </div>
+                    {% elif glossvideo.is_image %}
+                        <img src="{{glossvideo.get_absolute_url}}" alt="{{glossvideo.title}} - {{glossvideo.video_type}}" class="img-responsive center-block" />
                     {% endif %}
-                        {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
-                    </video>
                 </div>
             </section>
         </div>

--- a/signbank/dictionary/templates/dictionary/public_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/public_gloss_list.html
@@ -165,20 +165,21 @@ $( document ).ready(function() {
             </div>
             <div class="panel-body embed-responsive embed-responsive-16by9"
                  {% if obj.glossvideo_set.all.count > 0 %}style="background-color:rgb(33,33,33);"{% endif %}>
-            {% if obj.glossvideo_set.all.0 %}
-                <video id="glossvideo-{{obj.glossvideo_set.all.0.pk}}" class="video-public" preload="metadata" muted
-{% if obj.glossvideo_set.all.0.posterfile %} poster="{{obj.glossvideo_set.all.0.posterfile.url}}"{% endif %}
-                onclick="this.paused?this.play():this.pause();" playsinline>
-                {% if obj.glossvideo_set.all.0.get_extension == '.mp4' %}
-                    <source src="{{obj.glossvideo_set.all.0.videofile.url}}" type="video/mp4">
-                {% elif obj.glossvideo_set.all.0.get_extension == '.webm' %}
-                    <source src="{{obj.glossvideo_set.all.0.videofile.url}}" type="video/webm">
+            {% with glossvideo=obj.glossvideo_set.all.0 %}
+                {% if glossvideo %}
+                    {% if glossvideo.is_video %}
+                        <video id="glossvideo-{{glossvideo.pk}}" class="video-public" preload="metadata" muted
+        {% if glossvideo.posterfile %} poster="{{glossvideo.posterfile.url}}"{% endif %}
+                        onclick="this.paused?this.play():this.pause();" playsinline>
+                            <source src="{{glossvideo.get_absolute_url}}" type="{{glossvideo.get_content_type}}">
+                        </video>
+                    {% elif glossvideo.is_image %}
+                        <img src="{{glossvideo.get_absolute_url}}" alt="{{glossvideo.gloss.idgloss}" class="img-responsive" />
+                    {% endif %}
+                {% else %}
+                    <p><em>{% blocktrans %}No video.{% endblocktrans %}</em></p>
                 {% endif %}
-                    {% blocktrans %}Your browser does not support the video tag.{% endblocktrans %}
-                </video>
-            {% else %}
-                <p><em>{% blocktrans %}No video.{% endblocktrans %}</em></p>
-            {% endif %}
+            {% endwith %}
             </div>
             <div class="panel-footer">
             {% for glosstranslations in obj.glosstranslations_set.all %}

--- a/signbank/static/js/video-tooltip.js
+++ b/signbank/static/js/video-tooltip.js
@@ -8,9 +8,15 @@ $( document ).tooltip({
     if ( element.is( "[data-video-src]" ) ) {
       var src_video = element.attr("data-video-src");
       var src_poster = element.attr("data-thumbnail-src");
-      var video_ext = element.attr("data-video-ext");
-      if ( src_video != "") {
-        return "<video preload='none' autoplay muted poster='"+src_poster+"' width='250'><source src='"+src_video+"' type='video/"+video_ext+"'>Your browser does not support the video tag.</video>";
+      var content_type = element.attr("data-content-type");
+
+
+      if (!src_video) { return; }
+
+      if (content_type.startsWith("video/")) {
+        return "<video preload='none' autoplay muted poster='"+src_poster+"' width='250'><source src='"+src_video+"' type='"+content_type+"'>Your browser does not support the video tag.</video>";
+      } else if (content_type.startsWith("image/")) {
+        return "<img src='" + src_video + "' class='img-responsive' />";
       }
     }
   }

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import mimetypes
 import os
 
 from django.conf import settings
@@ -194,6 +195,18 @@ class GlossVideo(models.Model):
     def get_extension(self):
         """Returns videofiles extension."""
         return os.path.splitext(self.videofile.name)[1]
+
+    def get_content_type(self):
+        """ Returns the (guessed) mimetype of the videofile"""
+        content_type, encoding = mimetypes.guess_type(self.videofile.name)
+
+        return content_type
+
+    def is_image(self):
+        return self.get_content_type().startswith("image/")
+
+    def is_video(self):
+        return self.get_content_type().startswith("video/")
 
     def has_poster(self):
         """Returns true if the glossvideo has a poster file."""


### PR DESCRIPTION
This pull request updates the GlossVideo model to derive the content type of the glossvideo videofile, and then uses this content type to render an image tag instead of a video tag for image files. It also changes the fallback so that in detail views, nothing will be rendered if the file is not an image or video. This technically allows other files related to a gloss to be provided in the future (such as a PDF instruction sheet).

It's unfortunate (but understandable) that `GlossVideo` is called what it is , and not `GlossAsset`. Unfortunately, renaming this model and all references to `video` and `videofile` throughout the codebase is quite a big chore, and probably has limited value other than reducing the confusion between NZSL Signbank using GlossVideos to store _all_ types of asset representing the gloss, rather than just videos.

Admin detail view:

![image](https://user-images.githubusercontent.com/292020/173456123-86e4a1fc-1396-4410-ab96-c846d65658b5.png)


Admin detail view, in edit mode (note the 'set poster' button is disabled for non-video files):

![image](https://user-images.githubusercontent.com/292020/173456258-ba3e9234-33ff-47c6-a997-b7f61c77dd02.png)

Basic detail view:

![image](https://user-images.githubusercontent.com/292020/173456328-47bb6f61-55ab-4ff8-949b-4f23f8f3c541.png)

Gloss list view:

![image](https://user-images.githubusercontent.com/292020/173456415-6cba5eca-4f0c-41c9-9284-e837640df86d.png)

Admin search view (showing tooltip with image):

![image](https://user-images.githubusercontent.com/292020/173456510-2645aa42-50ed-4851-9a44-2b305dc5357b.png)


Admin search view (showing tooltip with video):

![image](https://user-images.githubusercontent.com/292020/173456607-d0961d7d-40fb-447b-8c37-0e5da5a55448.png)
