### PR TITLE
N2-121: Support glossrelations using AllowedTags

### DIFF
--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -2,15 +2,15 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.utils import OperationalError, ProgrammingError
-
+from django.utils.translation import ugettext_lazy as _
 from tagging.models import Tag
 
-from .models import Dataset, Language, SignLanguage, AllowedTags, GlossRelation, Gloss, Relation, \
-    RelationToForeignSign, MorphologyDefinition,  FieldChoice, GlossURL
+from .models import (AllowedTags, Dataset, FieldChoice, Gloss, GlossRelation,
+                     GlossURL, Language, MorphologyDefinition, Relation,
+                     RelationToForeignSign, SignLanguage)
 
 
 class GlossCreateForm(forms.ModelForm):
@@ -171,11 +171,13 @@ class GlossRelationSearchForm(forms.Form):
 
 class GlossRelationForm(forms.Form):
     source = forms.CharField(widget=forms.HiddenInput())
-    target = forms.CharField(label=_("Gloss"), widget=forms.TextInput(attrs={'class': 'glossrelation-autocomplete'}))
-    try:
-        qs = AllowedTags.objects.get(content_type=ContentType.objects.get_for_model(GlossRelation)).allowed_tags.all()
-    except (ObjectDoesNotExist, OperationalError, ProgrammingError):
-        qs = Tag.objects.all()
+    target = forms.CharField(label=_("Gloss"), widget=forms.TextInput(
+        attrs={'class': 'glossrelation-autocomplete'}))
+    allowed_tag = AllowedTags.objects.filter(
+        content_type=ContentType.objects.get_for_model(GlossRelation)).first()
+    qs = AllowedTags.objects.none()
+    if allowed_tag:
+        qs = allowed_tag.allowed_tags.all()
     tag = forms.ModelChoiceField(label=_("Relation type:"),
                                  queryset=qs,
                                  required=True, to_field_name='name',

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -735,7 +735,8 @@ def gloss_relation(request):
             target = get_object_or_404(Gloss, id=form.cleaned_data["target"])
             glossrelation = GlossRelation.objects.create(source=source, target=target)
             if form.cleaned_data["tag"]:
-                Tag.objects.add_tag(glossrelation, form.cleaned_data["tag"].name)
+                TaggedItem.objects.create(
+                    object=glossrelation, tag=form.cleaned_data["tag"])
             if "HTTP_REFERER" in request.META:
                 return redirect(request.META["HTTP_REFERER"])
             return redirect("/")


### PR DESCRIPTION
Two minor changes to allow us to use tagged GlossRelations as-is with FinSL:

1. The queryset in the gloss relation form should be empty if there is no AllowedTag record. This is a change to specifically suit NZSL, which requires discrete groups of tags for different purposes. We are also trying to refactor away from the `try/except everything` programming model in favour of presence-based logic, since capturing exceptions can hide genuine problems.
2. The update glossrelation operation receives a tag instance from the form, not a string of tags. This works for single-word tags, but since django-tagging attempts to parse the string, breaks for tags with spaces or commas. Since we have the instance, we can just create the join model.

With this change, relating glosses and reverse-relations just work. The "Search relations" page just works, as do relation methods in the admin and advanced gloss pages. 

In the future, it would be good to refactor the from to see if the `queryset` kwarg on the tag relation field can accept a function, so that we can load tags at runtime, rather than having to restart the server after adding or removing AllowedTag records. It would also be good to remove the 'Relation' model and related admin/advanced gloss fields, since the presence of this model can cause some confusion about how gloss relations work.