### PR TITLE
Update the queryset in the form so that allowed tags are loaded at runtime, not load time

### DIFF
--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -173,16 +173,18 @@ class GlossRelationForm(forms.Form):
     source = forms.CharField(widget=forms.HiddenInput())
     target = forms.CharField(label=_("Gloss"), widget=forms.TextInput(
         attrs={'class': 'glossrelation-autocomplete'}))
-    allowed_tag = AllowedTags.objects.filter(
-        content_type=ContentType.objects.get_for_model(GlossRelation)).first()
-    qs = AllowedTags.objects.none()
-    if allowed_tag:
-        qs = allowed_tag.allowed_tags.all()
     tag = forms.ModelChoiceField(label=_("Relation type:"),
-                                 queryset=qs,
+                                 queryset=AllowedTags.objects.none(),
                                  required=True, to_field_name='name',
                                  widget=forms.Select(attrs={'class': 'form-control'}))
     delete = forms.IntegerField(required=False, widget=forms.HiddenInput())
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        allowed_tag = AllowedTags.objects.filter(
+            content_type=ContentType.objects.get_for_model(GlossRelation)).first()
+        if allowed_tag:
+            self.fields['tag'].queryset = allowed_tag.allowed_tags.all()
 
 
 class GlossURLForm(forms.ModelForm):


### PR DESCRIPTION
This fixes a sneaky bug that stops the application starting if allowed tag objects cannot be found. This change makes the default queryset 'none' (e.g. an empty list), and loads the allowed tags in the __init__ function instead so they are loaded each time the form loads.