### PR TITLE
bugfix - N2-105 Topics/Semantic Fields

### DIFF
--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -177,9 +177,6 @@ function configure_edit() {
                           alert("There was an error processing this change: " + xhr.responseText );
                           original.reset();
                         };
-    $.fn.editable.defaults['onreset']  = function(settings, original, xhr){
-                          original.reset();
-                        };
 
 
      $('.edit_text').editable(edit_post_url);
@@ -232,11 +229,12 @@ function configure_edit() {
 	     this.textContent.split(/\n\s*/).indexOf(choices[key]) >= 0 && (selected.push(key));
         }
 
-         $(this).editable(edit_post_url, {
-             type: 'multicheckbox',
-             onblur: 'ignore',
-		     data: $.extend(choice_lists[$(this).attr('id')], { selected: selected })
-         })
+        $(this).editable(edit_post_url, {
+            type: 'multicheckbox',
+            onblur: 'ignore',
+            data: $.extend(choice_lists[$(this).attr('id')], { selected: selected }),
+            onreset: function(settings, original, xhr){original.reset()}
+        })
      });
 
      $('.edit_assignable_user').on('click', function() {


### PR DESCRIPTION
Small but important bugfix that was causing form errors for FieldChoices on Cancel, on the Advanced gloss page.

On Cancel the generic cleanup code was trying to write a blank string back to machine_value in FieldChoices. On Save everything worked fine.
This patch removes the generic cleaner (so for FieldChoices and no doubt some other fields nothing happens on Cancel - this is fine). It also gives edit_list_check its own cleaner that keeps the good behaviour the generic cleaner was trying to give it.
