### PR TITLE
Adding editorial queue

### DIFF
--- a/signbank/editorial_queue.py
+++ b/signbank/editorial_queue.py
@@ -1,0 +1,29 @@
+from .dictionary.models import Gloss
+from django.shortcuts import render
+from django_comments import get_model as django_comments_get_model
+
+
+def get_queue_items(request):
+    """
+        As per the first comment of N2-92, get the glosses which are assigned to you
+        """
+    user = request.user
+    print('URL **** ', request.path)
+    glosses = Gloss.objects.filter(assigned_user=user)
+    gloss_data = []
+    for gloss in glosses:
+        comments = django_comments_get_model().objects.filter(
+            object_pk=str(gloss.id),
+            is_removed=False,
+        ).order_by('-submit_date')[:3]
+        gloss_data.append({
+            'gloss': gloss,
+            'comments': comments
+        })
+
+    if 'details/' in request.path:
+        template = 'editorial_queue/queue_gloss_details.html'
+    else:
+        template = 'editorial_queue/queue.html'
+
+    return render(request, template, {'glosses': gloss_data})

--- a/signbank/editorial_queue.py
+++ b/signbank/editorial_queue.py
@@ -8,7 +8,6 @@ def get_queue_items(request):
         As per the first comment of N2-92, get the glosses which are assigned to you
         """
     user = request.user
-    print('URL **** ', request.path)
     glosses = Gloss.objects.filter(assigned_user=user)
     gloss_data = []
     for gloss in glosses:

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -15,6 +15,7 @@ from django.contrib.flatpages import views as flatpages_views
 from .comments import edit_comment, latest_comments, latest_comments_page, CommentListView, remove_tag
 import notifications.urls
 from .sitemaps import GlossSitemap, SignbankFlatPageSiteMap, StaticViewSitemap
+from .editorial_queue import get_queue_items
 # Forms
 from .customregistration.forms import CustomUserForm
 
@@ -75,6 +76,10 @@ urlpatterns = [
 
     # Infopage, where we store some links and statistics
     path('info/', infopage, name='infopage'),
+
+    # Editorial queue
+    path('queue/', get_queue_items, name='queue'),
+    path('queue/details/', get_queue_items, name='details'),
 ]
 if settings.DEBUG:
     import debug_toolbar

--- a/templates/editorial_queue/queue.html
+++ b/templates/editorial_queue/queue.html
@@ -1,0 +1,6 @@
+{% extends "baselayout.html" %}
+{% load i18n %}
+{% block bootstrap3_title %}{% blocktrans %}Glosses in the Queue{% endblocktrans %} | {% endblock %}
+{% block content %}
+{% include "editorial_queue/queue_gloss_details.html" %}
+{% endblock %}

--- a/templates/editorial_queue/queue.html
+++ b/templates/editorial_queue/queue.html
@@ -1,6 +1,6 @@
 {% extends "baselayout.html" %}
 {% load i18n %}
-{% block bootstrap3_title %}{% blocktrans %}Glosses in the Queue{% endblocktrans %} | {% endblock %}
+{% block bootstrap3_title %}{% blocktrans %}Editorial Queue{% endblocktrans %} | {% endblock %}
 {% block content %}
 {% include "editorial_queue/queue_gloss_details.html" %}
 {% endblock %}

--- a/templates/editorial_queue/queue_gloss_details.html
+++ b/templates/editorial_queue/queue_gloss_details.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+<div class="latest_comments">
+    <h2><a href="{% url 'search_comments' %}">{% blocktrans %}Glosses in the Queue{% endblocktrans %}</a></h2>
+{% for gloss in glosses %}
+    {% load tagging_tags %}
+    {% tags_for_object gloss.gloss as tag_list %}
+    <article class="gloss">
+        <header>
+            <h4 class="gloss-header"><a href="{{gloss.gloss.get_absolute_url}}"><strong>{{gloss.gloss.idgloss}}</strong>
+                <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <em>{{gloss.gloss.updated_at}}</em> -
+                <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{gloss.gloss.assigned_user}}</a>
+                {% if tag_list %}
+                    {% for tag in tag_list %}
+                <div class="comment-tags" style="display:inline;">
+                    <span class="label label-info" style="font-size:60%;">{{tag}}</span>
+                </div>
+                    {% endfor %}
+                {% endif %}
+            </h4>
+        </header>
+        {% if gloss.comments %}
+            <div class="panel panel-default">
+                {% for comment in gloss.comments %}
+                        <div class="panel-body">
+                            <p><b>{{comment.comment}}</b>  <em>{{ comment.submit_date }}</em>, <em>{{ comment.user }}</em></p>
+                        </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </article>
+{% endfor %}
+</div>

--- a/templates/editorial_queue/queue_gloss_details.html
+++ b/templates/editorial_queue/queue_gloss_details.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="latest_comments">
-    <h2><a href="{% url 'search_comments' %}">{% blocktrans %}Glosses in the Queue{% endblocktrans %}</a></h2>
+    <h2><a href="{% url 'queue' %}">{% blocktrans %}Editorial Queue{% endblocktrans %}</a></h2>
 {% for gloss in glosses %}
     {% load tagging_tags %}
     {% tags_for_object gloss.gloss as tag_list %}

--- a/templates/flatpages/frontpage.html
+++ b/templates/flatpages/frontpage.html
@@ -15,7 +15,7 @@
     {% if perms.dictionary.search_gloss %}
     <script type="text/javascript">
     $(document).ready(function() {
-     $('#front-right').load('/comments/latest/');
+     $('#front-right').load('/queue/details/');
     });
     </script>
     {% endif %}


### PR DESCRIPTION
JIRA Tickets: https://ackama.atlassian.net/browse/N2-113, https://ackama.atlassian.net/browse/N2-114

This PR adds the editorial queue as per the requirements described in above mentioned tickets. Added two URLs `queue/` and `queue/details` to show queue details in a stand-alone page and in the home page, respectively.

`queue/`:
![image](https://user-images.githubusercontent.com/5234605/175842301-6ae764a4-733d-4a8b-88a6-49b172db2e32.png)

'queue/details/ (in the home page)`:
![image](https://user-images.githubusercontent.com/5234605/175842349-85685858-6b72-41b9-bed0-1d008d75bbe0.png)
