### PR TITLE
N2-136 Remove fields from the Advanced gloss page.

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -231,20 +231,6 @@ class GlossListView(ListView):
         if 'notes' in get and get['notes'] != '':
             qs = qs.filter(notes__icontains=get['notes'])
 
-        # phonology and semantics field filters
-        """  for fieldname in fieldnames:
-
-            if fieldname in get:
-                key = fieldname + '__exact'
-                val = get[fieldname]
-
-                if isinstance(Gloss._meta.get_field(fieldname), NullBooleanField):
-                    val = {'0': '', '1': None, '2': True, '3': False}[val]
-
-                if val != '':
-                    kwargs = {key: val}
-                    qs = qs.filter(**kwargs) """
-
         if 'tags' in get and get['tags'] != '':
             vals = get.getlist('tags')
 
@@ -279,25 +265,6 @@ class GlossListView(ListView):
             qs = [q for q in qs if q not in tqs]
 
             # print "K :", len(qs)
-
-        """ if 'relationToForeignSign' in get and get['relationToForeignSign'] != '':
-            relations = RelationToForeignSign.objects.filter(
-                other_lang_gloss__icontains=get['relationToForeignSign'])
-            potential_pks = [relation.gloss.pk for relation in relations]
-            qs = qs.filter(pk__in=potential_pks) """
-
-        """ if 'hasRelationToForeignSign' in get and get['hasRelationToForeignSign'] != '0':
-
-            pks_for_glosses_with_relations = [
-                relation.gloss.pk for relation in RelationToForeignSign.objects.all()]
-            print(('pks_for_glosses', pks_for_glosses_with_relations))
-
-            # We only want glosses with a relation to a foreign sign
-            if get['hasRelationToForeignSign'] == '1':
-                qs = qs.filter(pk__in=pks_for_glosses_with_relations)
-            # We only want glosses without a relation to a foreign sign
-            elif get['hasRelationToForeignSign'] == '2':
-                qs = qs.exclude(pk__in=pks_for_glosses_with_relations) """
 
         if 'relation' in get and get['relation'] != '':
             potential_targets = Gloss.objects.filter(

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -200,13 +200,13 @@ class GlossListView(ListView):
 
 
         # A list of phonology fieldnames
-        fieldnames = ['handedness', 'strong_handshape', 'weak_handshape', 'location', 'relation_between_articulators',
+        """  fieldnames = ['handedness', 'strong_handshape', 'weak_handshape', 'location', 'relation_between_articulators',
                       'absolute_orientation_palm', 'absolute_orientation_fingers', 'relative_orientation_movement',
                       'relative_orientation_location', 'orientation_change', 'handshape_change', 'repeated_movement',
                       'alternating_movement', 'movement_shape', 'movement_direction', 'movement_manner',
                       'contact_type', 'phonology_other', 'mouth_gesture', 'mouthing', 'phonetic_variation',
                       'iconic_image', 'named_entity', 'number_of_occurences', 'fingerspelling',
-                      'one_or_two_hand', 'number_incorporated', 'locatable', 'directional', 'variant_no']
+                      'one_or_two_hand', 'number_incorporated', 'locatable', 'directional', 'variant_no'] """
 
         """These were removed from fieldnames because they are not needed there:
         'idgloss', 'idgloss_mi', 'notes',
@@ -232,7 +232,7 @@ class GlossListView(ListView):
             qs = qs.filter(notes__icontains=get['notes'])
 
         # phonology and semantics field filters
-        for fieldname in fieldnames:
+        """  for fieldname in fieldnames:
 
             if fieldname in get:
                 key = fieldname + '__exact'
@@ -243,7 +243,7 @@ class GlossListView(ListView):
 
                 if val != '':
                     kwargs = {key: val}
-                    qs = qs.filter(**kwargs)
+                    qs = qs.filter(**kwargs) """
 
         if 'tags' in get and get['tags'] != '':
             vals = get.getlist('tags')
@@ -280,13 +280,13 @@ class GlossListView(ListView):
 
             # print "K :", len(qs)
 
-        if 'relationToForeignSign' in get and get['relationToForeignSign'] != '':
+        """ if 'relationToForeignSign' in get and get['relationToForeignSign'] != '':
             relations = RelationToForeignSign.objects.filter(
                 other_lang_gloss__icontains=get['relationToForeignSign'])
             potential_pks = [relation.gloss.pk for relation in relations]
-            qs = qs.filter(pk__in=potential_pks)
+            qs = qs.filter(pk__in=potential_pks) """
 
-        if 'hasRelationToForeignSign' in get and get['hasRelationToForeignSign'] != '0':
+        """ if 'hasRelationToForeignSign' in get and get['hasRelationToForeignSign'] != '0':
 
             pks_for_glosses_with_relations = [
                 relation.gloss.pk for relation in RelationToForeignSign.objects.all()]
@@ -297,7 +297,7 @@ class GlossListView(ListView):
                 qs = qs.filter(pk__in=pks_for_glosses_with_relations)
             # We only want glosses without a relation to a foreign sign
             elif get['hasRelationToForeignSign'] == '2':
-                qs = qs.exclude(pk__in=pks_for_glosses_with_relations)
+                qs = qs.exclude(pk__in=pks_for_glosses_with_relations) """
 
         if 'relation' in get and get['relation'] != '':
             potential_targets = Gloss.objects.filter(

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -408,11 +408,6 @@ $('#id_comment').atwho({
                     <td class="edit edit_list_check" id="wordclass">{{gloss.wordclasses.all|join:", "}}</td>
                 </tr>
 
-                {# Translators: Information about a Gloss #}
-                <tr>
-                    <th>{% blocktrans %}Sign language:{% endblocktrans %}</th>
-                    <td id='signlanguage'>{{dataset.signlanguage}}</td>
-                </tr>
                 <tr>
                     <th>{% blocktrans %}Sign number:{% endblocktrans %}</th>
                     <td id='sign-number'>{{gloss.id}}</td>

--- a/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
@@ -108,26 +108,6 @@
         <div class='panel-heading'>
             <div class='panel-title'>
                 {# Translators: #}
-                <a data-toggle='collapse' data-parent='#definition' href='#phonology'>
-                    {% blocktrans %}Phonology{% endblocktrans %}</a>
-            </div>
-        </div>
-        <div id='phonology' class='panel-collapse collapse'>
-            <table class='table table-condensed'>
-                {% for value,name,label,kind in phonology_fields %}
-                <tr>
-                    <th>{{label}}</th>
-                    <td class="edit edit_{{kind}}" id='{{name}}'>{% if kind == "check" and value is None%}No{% elif kind == "check" and value != 'No' %}Yes{% else %}{% value value %}{% endif %}</td>
-                </tr>
-                {% endfor %}
-            </table>
-        </div>
-    </div>
-
-    <div class="panel panel-default">
-        <div class='panel-heading'>
-            <div class='panel-title'>
-                {# Translators: #}
                 <a data-toggle='collapse' data-parent='#definition' href='#semantics'>
                     {% blocktrans %}Semantics{% endblocktrans %}</a>
             </div>
@@ -233,103 +213,7 @@
         </div>
     </div>
 
-    <div class="panel panel-default">
-        <div class='panel-heading'>
-            <div class='panel-title'>
-                {# Translators: #}
-                <a data-toggle='collapse' data-parent='#definition' href='#relationsforeign'>
-                    {% blocktrans %}Relations to Foreign Signs{% endblocktrans %}</a>
-            </div>
-        </div>
-        <div id='relationsforeign' class='collapse'>
-            <table class='table table-condensed'>
-                <tr>
-                    <th style='width:1em'></th>
-                    {# Translators: Loan from another language(?) #}
-                    <th style='width:3em'>{% blocktrans %}Loan{% endblocktrans %}</th>
-                    {# Translators: #}
-                    <th style='width:6em'>{% blocktrans %}Related Language{% endblocktrans %}</th>
-                    {# Translators: Equivalent Gloss in related language #}
-                    <th style='width:10em'>{% blocktrans %}Gloss in related language{% endblocktrans %}</th>
-                </tr>
-
-                {% for rel in gloss.relationtoforeignsign_set.all %}
-                <tr>
-                    <td>
-                        <span class='glyphicon glyphicon-trash relation_delete' data-toggle='modal'
-                              data-target='#delete_relation_modal_{{rel.id}}'></span>
-
-                        <div class="modal fade" id="delete_relation_modal_{{rel.id}}" role="dialog"
-                             aria-labelledby="#modalTitle" aria-hidden="true">
-                            <div class="modal-dialog modal-sm">
-                                <div class="modal-content">
-                                    <div class='modal-header'>
-                                        {# Translators: Header2 #}
-                                        <h2 id='modalTitle'>
-                                            {% blocktrans %}Delete This Relation{% endblocktrans %}</h2>
-                                    </div>
-                                    <div class='modal-body'>
-                                        {# Translators: Question #}
-                                        <p>{% blocktrans %}Are you sure you want to delete this? This cannot be
-                                            undone.{% endblocktrans %}</p>
-                                    </div>
-                                    <form action='{% url "dictionary:update_gloss" gloss.id %}' method='post'>
-                                        {% csrf_token %}
-                                        <input type='hidden' name='id' value='relationforeigndelete_{{rel.id}}'>
-                                        <input type='hidden' name='value' value='confirmed'>
-
-                                        <div class="modal-footer">
-                                            {# Translators: Button #}
-                                            <button type="button" class="btn btn-default" data-dismiss="modal">
-                                                {% blocktrans %}Cancel{% endblocktrans %}
-                                            </button>
-                                            {# Translators: Submit button #}
-                                            <input type="submit" class="btn btn-primary"
-                                                   value='{% blocktrans %}Confirm Delete{% endblocktrans %}'>
-                                        </div>
-                                    </form>
-
-                                </div>
-                            </div>
-                        </div>
-
-                    </td>
-
-                    <td class='edit edit_check' id='relationforeign-loan_{{rel.id}}'>{{rel.loan}}</td>
-                    <td class='edit edit_text' id='relationforeign-other-lang_{{rel.id}}'>{{rel.other_lang}}</td>
-                    <td class='edit edit_text' id='relationforeign-other-lang-gloss_{{rel.id}}'>
-                        {{rel.other_lang_gloss}}
-                    </td>
-                    {% endfor %}
-            </table>
-
-            {% if perms.dictionary.change_gloss %}
-            <form id='add_relationtoforeignsign_form' method='post' action='{% url 'dictionary:add_relationtoforeignsign' %}'>
-            {% csrf_token %}
-            <input type='hidden' name='sourceid' value='{{gloss.pk}}'>
-            <table class='table table-condensed'>
-                <tr>
-                    <td><input class='checkbox' name='loan' type='checkbox'></td>
-                    {# Translators: #}
-                    <td><input class='form-control'
-                               placeholder='{% blocktrans %}Related language{% endblocktrans %}' name='other_lang'
-                               type='text'></td>
-                    {# Translators: #}
-                    <td><input class='form-control'
-                               placeholder='{% blocktrans %}Gloss in related language{% endblocktrans %}'
-                               name='other_lang_gloss' type='text'></td>
-                    {# Translators: #}
-                    <td><input class='btn btn-primary'
-                               value='{% blocktrans %}Add Relation to Foreign Sign{% endblocktrans %}'
-                               type='submit'></td>
-                </tr>
-            </table>
-            </form>
-            {% endif %}
-        </div>
-    </div>
-
-    <div class="panel panel-default">
+     <div class="panel panel-default">
         <div class='panel-heading'>
             <div class='panel-title'>
                 <a data-toggle='collapse' data-parent='#definition' href='#usage_variation'>


### PR DESCRIPTION
Fields removed:
 Top:
  Sign language
 Advanced:
  Phonology
  Relations to Foreign Signs
Code supporting display of these fields has been removed from adminviews.py.

Before:
![BEFORE n2-136 fields removed dictionary-advanced-gloss](https://user-images.githubusercontent.com/82071930/176099916-755f077f-abe9-4f85-9c4f-eb9f9adf5d9e.png)


After:
![AFTER n2-136 fields removed dictionary-advanced-gloss png](https://user-images.githubusercontent.com/82071930/176100036-d0eb0eba-129d-4c56-b0e6-c005f37e6986.png)



