### PR TITLE
Feature/n2 140 tabs advanced page

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -156,6 +156,19 @@ $('#id_comment').atwho({
     {% endif %}
 </div>
 
+{# Tabs nav bar #}
+<ul class="nav nav-tabs" role="tablist">
+    <li class="active"><a href="#gloss_main_edit_tab" role="tab" data-toggle="tab">Edit</a></li>
+    <li><a href="#gloss_public_view_tab" role="tab" data-toggle="tab">Public View</a></li>
+    <li><a href="#gloss_revision_history_tab" role="tab" data-toggle="tab">Revision History</a></li>
+  </ul>
+
+{# Tabs wrapper #}
+<div class="tab-content">
+
+{# Tab: main gloss editing pane #}
+<div class="tab-pane active" id="gloss_main_edit_tab">
+
 <div id="signinfo" class='navbar navbar-default navbar-collapse'>
     <div id="datasetname" class="pull-left">
         <h4>{% blocktrans%}Dataset{% endblocktrans %}: <span class="dataset-{{gloss.dataset.id}}-color label label-default">{{dataset}}</span></h4>
@@ -539,5 +552,20 @@ $('#id_comment').atwho({
     </div>
 
 </div>
+
+
+</div>
+
+{# Tab: Signbank Dictionary public view pane #}
+<div class="tab-pane" id="gloss_public_view_tab">
+</div>
+
+{# Tab: gloss editing Revision History pane #}
+<div class="tab-pane" id="gloss_revision_history_tab">
+</div>
+
+
+</div>
+{# Tabs wrapper #}}
 
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -159,7 +159,7 @@ $('#id_comment').atwho({
 {# Tabs nav bar #}
 <ul class="nav nav-tabs" role="tablist">
     <li class="active"><a href="#gloss_main_edit_tab" role="tab" data-toggle="tab">Edit</a></li>
-    <li><a href="#gloss_public_view_tab" role="tab" data-toggle="tab">Public View</a></li>
+    <li><a href="#gloss_public_dictionary_tab" role="tab" data-toggle="tab">Public View</a></li>
     <li><a href="#gloss_revision_history_tab" role="tab" data-toggle="tab">Revision History</a></li>
   </ul>
 
@@ -169,6 +169,7 @@ $('#id_comment').atwho({
 {# Tab: main gloss editing pane #}
 <div class="tab-pane active" id="gloss_main_edit_tab">
 
+{# div not indented to ease code diffing #}
 <div id="signinfo" class='navbar navbar-default navbar-collapse'>
     <div id="datasetname" class="pull-left">
         <h4>{% blocktrans%}Dataset{% endblocktrans %}: <span class="dataset-{{gloss.dataset.id}}-color label label-default">{{dataset}}</span></h4>
@@ -189,7 +190,7 @@ $('#id_comment').atwho({
     </div>
     {% endif %}
 </div>
-
+{# div not indented to ease code diffing #}
 <div class="container-fluid">
     <div id="definitionblock" class="row">
         <div id="leftblock" class="col-lg-5 col-md-6 col-sm-12 col-xs-12">
@@ -553,16 +554,20 @@ $('#id_comment').atwho({
 
 </div>
 
-
 </div>
+{# Tab: main gloss editing pane #}
 
 {# Tab: Signbank Dictionary public view pane #}
-<div class="tab-pane" id="gloss_public_view_tab">
+<div class="tab-pane" id="gloss_public_dictionary_tab">
+    {% include "dictionary/gloss_public_dictionary_tab.html" %}
 </div>
+{# Tab: Signbank Dictionary public view pane #}
 
 {# Tab: gloss editing Revision History pane #}
 <div class="tab-pane" id="gloss_revision_history_tab">
+    {% include "dictionary/gloss_revision_history_tab.html" %}
 </div>
+{# Tab: gloss editing Revision History pane #}
 
 
 </div>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -566,6 +566,6 @@ $('#id_comment').atwho({
 
 
 </div>
-{# Tabs wrapper #}}
+{# Tabs wrapper #}
 
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -156,6 +156,19 @@ $('#id_comment').atwho({
     {% endif %}
 </div>
 
+{# Tabs nav bar #}
+<ul class="nav nav-tabs" role="tablist">
+    <li class="active"><a href="#gloss_main_edit_tab" role="tab" data-toggle="tab">Edit</a></li>
+    <li><a href="#gloss_public_view_tab" role="tab" data-toggle="tab">Public View</a></li>
+    <li><a href="#gloss_revision_history_tab" role="tab" data-toggle="tab">Revision History</a></li>
+  </ul>
+
+{# Tabs wrapper #}
+<div class="tab-content">
+
+{# Tab: main gloss editing pane #}
+<div class="tab-pane active" id="gloss_main_edit_tab">
+
 <div id="signinfo" class='navbar navbar-default navbar-collapse'>
     <div id="datasetname" class="pull-left">
         <h4>{% blocktrans%}Dataset{% endblocktrans %}: <span class="dataset-{{gloss.dataset.id}}-color label label-default">{{dataset}}</span></h4>
@@ -527,5 +540,20 @@ $('#id_comment').atwho({
     </div>
 
 </div>
+
+
+</div>
+
+{# Tab: Signbank Dictionary public view pane #}
+<div class="tab-pane" id="gloss_public_view_tab">
+</div>
+
+{# Tab: gloss editing Revision History pane #}
+<div class="tab-pane" id="gloss_revision_history_tab">
+</div>
+
+
+</div>
+{# Tabs wrapper #}}
 
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -554,6 +554,6 @@ $('#id_comment').atwho({
 
 
 </div>
-{# Tabs wrapper #}}
+{# Tabs wrapper #}
 
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/gloss_public_dictionary_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_public_dictionary_tab.html
@@ -1,0 +1,6 @@
+{% load stylesheet %}
+{% load bootstrap3 %}
+{% load i18n %}
+{% load static %}
+
+PUBLIC DICTIONARY TAB

--- a/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
@@ -1,0 +1,6 @@
+{% load stylesheet %}
+{% load bootstrap3 %}
+{% load i18n %}
+{% load static %}
+
+REVISION HISTORY TAB


### PR DESCRIPTION
Uses Bootstrap library to give Gloss Advanced edit page clickable tabs.
The tabs are currently:
Edit - the familiar edit page with the Enable/Disable Edit button.
Public View - to house the view of the Gloss on the Signbank Dictionary site if it is published there.
Revision History - to house the Revision History of the gloss.
The tabs besides Edit have been left blank internally. The two new tabs break out to stub files that have been created ready to be filled out.
Their respective Jira tickets have been updated with their details to help developers get started.

A video showing the tabs working is attached below:

https://user-images.githubusercontent.com/82071930/176081480-3494957d-08e7-4937-a11f-2ccf1905eda0.mp4


