### PR TITLE
Adding one or two handed to advanced search

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -269,6 +269,10 @@ class GlossListView(ListView):
             val = get['location']
             qs = qs.filter(location=val)
 
+        if 'one_or_two_handed' in get and get['one_or_two_handed'] != '':
+            val = get['one_or_two_handed'] == 'on'
+            qs = qs.filter(one_or_two_hand=val)
+
         if 'relation' in get and get['relation'] != '':
             potential_targets = Gloss.objects.filter(
                 idgloss__icontains=get['relation'])

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -108,6 +108,8 @@ class GlossSearchForm(forms.ModelForm):
     location = forms.ModelChoiceField(label=_('Location'), queryset=FieldChoice.objects.filter(field='location'),
                                       to_field_name='machine_value', required=False)
 
+    one_or_two_handed = forms.BooleanField(label=_('One or two handed'), required=False)
+
     # These have been disabled until they are later needed
     # TODO: To enable these, uncomment them.
     """

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -126,6 +126,7 @@ function clearForm(myFormElement) {
                           <li class="list-group-item list-group-item-warning">{% bootstrap_field searchform.hasvideo show_label=False bound_css_class="not-bound" %}</li>
                           <li class="list-group-item list-group-item-danger">{% bootstrap_field searchform.hasnovideo show_label=False bound_css_class="not-bound" %}</li>
                           <li class="list-group-item">{% bootstrap_field searchform.multiplevideos show_label=False bound_css_class="not-bound" %}</li>
+                          <li class="list-group-item">{% bootstrap_field searchform.one_or_two_handed show_label=False bound_css_class="not-bound" %}</li>
                         </ul>
                 </div>
                 <div class="col-md-6 col-sm-6 searchinput">


### PR DESCRIPTION
JIRA Ticket: https://ackama.atlassian.net/browse/N2-150

This PR adds `one_or_two_hand` as a search parameter to the advance search page.

![image](https://user-images.githubusercontent.com/5234605/177225262-19a20ad7-1ac0-4e5c-9b50-77c9296096d1.png)
