### PR TITLE
Adding wordclasses to advance search

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -302,6 +302,10 @@ class GlossListView(ListView):
             val = get['strong_handshape']
             qs = qs.filter(strong_handshape=val)
 
+        if 'word_classes' in get and get['word_classes'] != '':
+            vals = get.getlist('word_classes')
+            qs = qs.filter(wordclasses__id__in=vals)
+
         if 'relation' in get and get['relation'] != '':
             potential_targets = Gloss.objects.filter(
                 idgloss__icontains=get['relation'])

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -126,6 +126,9 @@ class GlossSearchForm(forms.ModelForm):
     strong_handshape = forms.ModelChoiceField(label=_('Strong handshape'), queryset=FieldChoice.objects.filter(field='strong_handshape'),
                                               to_field_name='machine_value', required=False)
     one_or_two_handed = forms.BooleanField(label=_('One or two handed'), required=False)
+    word_classes = forms.ModelMultipleChoiceField(label=_('Word classes'),
+                                                  queryset=FieldChoice.objects.filter(field='wordclass'),
+                                                  required=False)
 
     # These have been disabled until they are later needed
     # TODO: To enable these, uncomment them.

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -179,6 +179,18 @@ function clearForm(myFormElement) {
                            {% bootstrap_field searchform.relation_to_foreign_signs show_label=False bound_css_class="not-bound" %}
                        </div>
                 </div>
+                <div class="col-md-6 col-sm-6 searchinput">
+                      <div class="input-group">
+                           <label class="input-group-addon" for="id_strong_handshape">{{searchform.strong_handshape.label}}</label>
+                           {% bootstrap_field searchform.strong_handshape show_label=False bound_css_class="not-bound" %}
+                       </div>
+                </div>
+                <div class="col-md-6 col-sm-6 searchinput">
+                     <div class="input-group">
+                         <label class="input-group-addon" for="id_word_classes">{{searchform.word_classes.label}}</label>
+                         {% bootstrap_field searchform.word_classes show_label=False bound_css_class="not-bound" %}
+                     </div>
+                </div>
             </div>
         </div>
         <hr class="searchform-separator">


### PR DESCRIPTION
JIRA Ticket: https://ackama.atlassian.net/browse/N2-151

This PR adds the `wordclasses` as a search parameter to the advance search. Also, added the front-end component of `strong_hand` to the same page. 

![image](https://user-images.githubusercontent.com/5234605/177251025-1d9a56bc-58cf-4146-924c-707b3f83e631.png)
