### PR TITLE
Restoring Phonology section accidentally removed from Advanced page in N2-136.

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -198,20 +198,14 @@ class GlossListView(ListView):
             # Include glosses that have more than one GlossVideo
             qs = qs.annotate(videocount=Count('glossvideo')).filter(videocount__gt=1)
 
-
         # A list of phonology fieldnames
-        """  fieldnames = ['handedness', 'strong_handshape', 'weak_handshape', 'location', 'relation_between_articulators',
+        fieldnames = ['handedness', 'strong_handshape', 'weak_handshape', 'location', 'relation_between_articulators',
                       'absolute_orientation_palm', 'absolute_orientation_fingers', 'relative_orientation_movement',
                       'relative_orientation_location', 'orientation_change', 'handshape_change', 'repeated_movement',
                       'alternating_movement', 'movement_shape', 'movement_direction', 'movement_manner',
                       'contact_type', 'phonology_other', 'mouth_gesture', 'mouthing', 'phonetic_variation',
                       'iconic_image', 'named_entity', 'number_of_occurences', 'fingerspelling',
-                      'one_or_two_hand', 'number_incorporated', 'locatable', 'directional', 'variant_no'] """
-
-        """These were removed from fieldnames because they are not needed there:
-        'idgloss', 'idgloss_mi', 'notes',
-        """
-
+                      'one_or_two_hand', 'number_incorporated', 'locatable', 'directional', 'variant_no']
 
         # Language and basic property filters
         vals = get.getlist('dialect', [])
@@ -229,6 +223,17 @@ class GlossListView(ListView):
         if 'semantic_field' in get and get['semantic_field'] != '':
             vals = get.getlist('semantic_field')
             qs = qs.filter(semantic_field__id__in=vals)
+
+        # phonology and semantics field filters
+        for fieldname in fieldnames:
+            if fieldname in get:
+                key = fieldname + '__exact'
+                val = get[fieldname]
+                if isinstance(Gloss._meta.get_field(fieldname), NullBooleanField):
+                    val = {'0': '', '1': None, '2': True, '3': False}[val]
+                if val != '':
+                    kwargs = {key: val}
+                    qs = qs.filter(**kwargs)
 
         if 'tags' in get and get['tags'] != '':
             vals = get.getlist('tags')
@@ -280,9 +285,9 @@ class GlossListView(ListView):
 
         if 'example_search' in get and get['example_search'] != '':
             """
-                This search is intended to search for gloss IDs in fields videoexample1 to videoexample4. In these 
-                fields, gloss IDs are within square brackets (eg: cat[123], 123 is the gloss ID). 
-                When we search for a gloss ID (eg: 123), the search should return all the glosses that contain gloss ID 
+                This search is intended to search for gloss IDs in fields videoexample1 to videoexample4. In these
+                fields, gloss IDs are within square brackets (eg: cat[123], 123 is the gloss ID).
+                When we search for a gloss ID (eg: 123), the search should return all the glosses that contain gloss ID
                 123 in one of their videoexample fields.
                 Search parameter is just the gloss id, so we are adding []s before doing the search.
             """
@@ -345,7 +350,7 @@ class GlossListView(ListView):
         if 'usage' in get and get['usage'] != '':
             vals = get.getlist('usage')
             qs = qs.filter(usage__id__in=vals)
-            
+
         # Set order according to GET field 'order'
         if 'order' in get:
             qs = qs.order_by(get['order'])
@@ -484,11 +489,9 @@ class GlossDetailView(DetailView):
         fields['morphology'] = ['number_incorporated', 'locatable', 'directional', 'fingerspelling',
                                 'inflection_temporal', 'inflection_manner_degree', 'inflection_plural']
         fields['phonology'] = ['handedness', 'strong_handshape', 'weak_handshape', 'handshape_change',
-                               'relation_between_articulators', 'location', 'absolute_orientation_palm',
-                               'absolute_orientation_fingers', 'relative_orientation_movement',
-                               'relative_orientation_location', 'orientation_change', 'contact_type', 'movement_shape',
-                               'movement_direction', 'movement_manner', 'repeated_movement', 'alternating_movement',
-                               'phonology_other', 'mouth_gesture', 'mouthing', 'phonetic_variation', 'one_or_two_hand']
+                               'relation_between_articulators', 'location', 'contact_type',
+                               'repeated_movement', 'alternating_movement',
+                               'mouth_gesture', 'mouthing', 'phonetic_variation', 'one_or_two_hand']
 
         fields['semantics'] = ['iconic_image',
                                'named_entity']

--- a/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
@@ -9,6 +9,27 @@
 
 {% if perms.dictionary.view_advanced_properties %}
 <div id="advanced-properties">
+
+    <div class="panel panel-default">
+        <div class='panel-heading'>
+            <div class='panel-title'>
+                {# Translators: #}
+                <a data-toggle='collapse' data-parent='#definition' href='#phonology'>
+                    {% blocktrans %}Phonology{% endblocktrans %}</a>
+            </div>
+        </div>
+        <div id='phonology' class='panel-collapse collapse'>
+            <table class='table table-condensed'>
+                {% for value,name,label,kind in phonology_fields %}
+                <tr>
+                    <th>{{label}}</th>
+                    <td class="edit edit_{{kind}}" id='{{name}}'>{% if kind == "check" and value is None%}No{% elif kind == "check" and value != 'No' %}Yes{% else %}{% value value %}{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
+
     <div class="panel panel-default">
         <div class='panel-heading'>
             <div class='panel-title'>


### PR DESCRIPTION
I accidentally removed the entire Phonology section from the Advanced page while executing N2-136.
Only the following fields were supposed to be removed:
Absolute orientation (all), Relative orientation (all), Orientation change, Movement shape/direction/manner, Phonology other.
The section has been restored to the Advanced page, with the fields above removed:

![image](https://user-images.githubusercontent.com/82071930/177256704-a09b20c5-1cc1-46a0-b0e0-472bad14f49e.png)

