### PR TITLE
Removing duplicate of relation to foreign sign

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -175,12 +175,6 @@ function clearForm(myFormElement) {
                 </div>
                 <div class="col-md-6 col-sm-6 searchinput">
                       <div class="input-group">
-                           <label class="input-group-addon" for="id_relation_to_foreign_signs">{{searchform.relation_to_foreign_signs.label}}</label>
-                           {% bootstrap_field searchform.relation_to_foreign_signs show_label=False bound_css_class="not-bound" %}
-                       </div>
-                </div>
-                <div class="col-md-6 col-sm-6 searchinput">
-                      <div class="input-group">
                            <label class="input-group-addon" for="id_strong_handshape">{{searchform.strong_handshape.label}}</label>
                            {% bootstrap_field searchform.strong_handshape show_label=False bound_css_class="not-bound" %}
                        </div>


### PR DESCRIPTION
This PR is to fix the duplication of relation to foreign signs in the advance search page.

![image](https://user-images.githubusercontent.com/5234605/177427424-29a9a09d-1023-44c8-a54d-97c12d1008fd.png)
