### PR TITLE
Updating sentry configuration

### DIFF
--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -9,6 +9,19 @@ import sys
 import dj_database_url
 from django.utils.translation import ugettext_lazy as _
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+sentry_dsn = os.environ.get('SENTRY_DSN', '')
+
+if sentry_dsn != '':
+    sentry_sdk.init(
+        dsn=os.environ.get('SENTRY_DSN'),
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+        send_default_pii=True
+    )
+
 try:
     # settings_secret.py is imported in this settings file, you should put the sensitive information in that file.
     from signbank.settings.settings_secret import *

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -9,12 +9,14 @@ import sys
 import dj_database_url
 from django.utils.translation import ugettext_lazy as _
 
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 
 sentry_dsn = os.environ.get('SENTRY_DSN', '')
 
 if sentry_dsn != '':
+
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
     sentry_sdk.init(
         dsn=os.environ.get('SENTRY_DSN'),
         integrations=[DjangoIntegration()],

--- a/signbank/settings/production.py
+++ b/signbank/settings/production.py
@@ -3,21 +3,11 @@
 """Production environment specific settings for FinSL-signbank."""
 from __future__ import unicode_literals
 
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 from signbank.settings.base import *
 
 # settings.base imports settings_secret
 # The following settings are defined in settings_secret:
 # SECRET_KEY, ADMINS, DATABASES, EMAIL_HOST, EMAIL_PORT, DEFAULT_FROM_EMAIL
-
-
-sentry_sdk.init(
-    dsn=os.environ.get('SENTRY_DSN'),
-    integrations=[DjangoIntegration()],
-    traces_sample_rate=1.0,
-    send_default_pii=True
-)
 
 # This setting defines the additional locations the staticfiles app will traverse if the FileSystemFinder finder
 # is enabled, e.g. if you use the collectstatic or findstatic management command or use the static file serving view.


### PR DESCRIPTION
This PR has taken out the sentry configuration out of the `production.py`, so that the sentry error monitoring will happen for any environment which has the variable `SENTRY_DSN` is stored.