### PR TITLE
N2-154 Revision History Tab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ CMD pip install -r requirements.txt && \
     bin/develop.py migrate --noinput && \
     bin/develop.py createcachetable && \
     bin/develop.py loaddata signbank/contentpages/fixtures/flatpages_initial_data.json &&\
+    bin/develop.py createinitialrevisions &&\
     gunicorn signbank.wsgi --bind=0.0.0.0:${PORT:=8000}
 
 EXPOSE 8000

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -34,7 +34,6 @@ from .models import (Dataset, Gloss, GlossRelation, GlossTranslations,
                      GlossURL, MorphologyDefinition, Relation,
                      RelationToForeignSign, Translation, FieldChoice)
 
-
 class GlossListView(ListView):
     model = Gloss
     template_name = 'dictionary/admin_gloss_list.html'
@@ -303,7 +302,7 @@ class GlossListView(ListView):
         if 'strong_handshape' in get and get['strong_handshape'] != '':
             val = get['strong_handshape']
             qs = qs.filter(strong_handshape=val)
-            
+
         if 'word_classes' in get and get['word_classes'] != '':
             vals = get.getlist('word_classes')
             qs = qs.filter(wordclasses__id__in=vals)
@@ -486,28 +485,92 @@ class GlossDetailView(DetailView):
         context['translation_languages_and_translations'] = gloss.get_translations_for_translation_languages()
 
         if self.request.user.is_staff:
-            # Get some version history data
-            version_history = Version.objects.get_for_object(
-                context['gloss']).prefetch_related('revision__user')[:20]
-            translation_ct = ContentType.objects.get_for_model(Translation)
-            for i, version in enumerate(version_history):
-                if not i+1 >= len(version_history):
-                    ver1 = version.field_dict
-                    ver2 = version_history[i+1].field_dict
-                    t1 = list(version_history[i].revision.version_set.filter(
-                        content_type=translation_ct).values_list('object_repr', flat=True))
-                    t2 = list(version_history[i+1].revision.version_set.filter(
-                        content_type=translation_ct).values_list('object_repr', flat=True))
-                    version.translations_added = ", ".join(
-                        ["+"+x for x in t1 if x not in set(t2)])
-                    version.translations_removed = ", ".join(
-                        ["-"+x for x in t2 if x not in set(t1)])
-                    version.data_removed = dict([(key, value) for key, value in ver1.items() if value != ver2[key] and
-                                                 key != 'updated_at' and key != 'updated_by_id'])
-                    version.data_added = dict([(key, value) for key, value in ver2.items() if value != ver1[key] and
-                                              key != 'updated_at' and key != 'updated_by_id'])
 
-            context['revisions'] = version_history
+            # Using the Reversion middleware, get version history data:
+            # This is an iterable of Version instance, each of which contains data including:
+            #   * A dict of fieldname => field for this model (in this case Gloss)
+            #   * A Revision instance with:
+            #       Metadata stored when the Version was created
+            #       References to the state of all other model instances under Reversion control at the time the Version was saved
+            #           (eg. Translation instances)
+            version_history = Version.objects.get_for_object(gloss).prefetch_related('revision__user')
+
+            # Get ContentType for Translation model so we can retrieve Translation instance states from Reversion
+            translation_contenttype = ContentType.objects.get_for_model(Translation)
+
+            revisions = []
+            revisions_ignore = ('updated_at')
+            gloss_fieldchoice_fields=['handedness', 'strong_handshape', 'weak_handshape', 'location', 'relation_between_articulators',
+                                      'absolute_orientation_palm', 'absolute_orientation_fingers', 'relative_orientation_movement',
+                                      'relative_orientation_location', 'orientation_change', 'handshape_change', 'movement_shape',
+                                      'movement_direction', 'movement_manner', 'contact_type', 'wordclasses', 'usage', 'named_entity',
+                                      'semantic_field', 'signer', 'age_variation']
+
+            # Determine which fields have changed
+            for i, version_hist_entry in enumerate(version_history):
+                if i+1 >= len(version_history):
+                    continue
+
+                # Regular fields
+                for key, value in version_hist_entry.field_dict.items():
+                    if key in revisions_ignore:
+                        continue
+
+                    changed_new = value
+                    changed_old = version_history[i+1].field_dict[key]
+
+                    if changed_new != changed_old:
+
+                        # Reversion gives us the field name, which for a ForeignKey is sometimes the db column name with '_id'
+                        # NOTE removesuffix() is new in Python 3.9
+                        keycut=key.removesuffix('_id')
+
+                        # Use the raw field name (key) to retrieve the field verbose name
+                        # This works in Django regardless of whether the key is a field name or db column name
+                        changed_field_verbosename=Gloss._meta.get_field(key).verbose_name
+
+                        if keycut in gloss_fieldchoice_fields:
+
+                            # If we were given a straight FieldChoice field name, then the values contained in the revision
+                            # are primary keys of FieldChoice records.
+                            # But if we were given a dictionary_fieldchoice db column name - ie. if it had '_id' on the end - then
+                            # the value in the revision is a (single, unique) machine_value number instead.
+                            # We have to adjust our QuerySet filters accordingly.
+                            if key != keycut:
+                                changed_old_qs = FieldChoice.objects.filter(machine_value=changed_old).values_list('english_name', flat=True)
+                                changed_new_qs = FieldChoice.objects.filter(machine_value=changed_new).values_list('english_name', flat=True)
+                            else:
+                                changed_old_qs = FieldChoice.objects.filter(pk__in=changed_old).values_list('english_name', flat=True)
+                                changed_new_qs = FieldChoice.objects.filter(pk__in=changed_new).values_list('english_name', flat=True)
+                            changed_old = ', '.join(list(changed_old_qs))
+                            changed_new = ', '.join(list(changed_new_qs))
+
+                        if changed_old in ('', None):
+                            changed_old = '-'
+                        if changed_new in ('', None):
+                            changed_new = '-'
+
+                        revisions.append((version_hist_entry.revision.user.username, version_hist_entry.revision.date_created,
+                                            changed_field_verbosename, changed_old, changed_new))
+
+                # Translations
+                translations_new = list(version_history[i].revision.version_set.filter(
+                    content_type=translation_contenttype).values_list('object_repr', flat=True))
+                translations_old = list(version_history[i+1].revision.version_set.filter(
+                    content_type=translation_contenttype).values_list('object_repr', flat=True))
+
+                # Ignore pairs of empty lists
+                if not (translations_new or translations_old):
+                    continue
+
+                # This will catch re-orderings as well
+                translations_new_str = ", ".join(translations_new)
+                translations_old_str = ", ".join(translations_old)
+                if (translations_new_str != translations_old_str):
+                    revisions.append((version_hist_entry.revision.user.username, version_hist_entry.revision.date_created,
+                                      'Translations', translations_old_str, translations_new_str))
+
+            context['revisions'] = revisions
 
         # Pass info about which fields we want to see
         gl = context['gloss']

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -288,7 +288,7 @@ class RelationToForeignSign(models.Model):
     def __str__(self):
         return str(self.gloss) + "/" + str(self.other_lang) + ',' + str(self.other_lang_gloss)
 
-
+@reversion.register()
 class FieldChoice(models.Model):
     #: The name of the FieldChoice.
     field = models.CharField(max_length=50)
@@ -669,6 +669,9 @@ class Gloss(models.Model):
                 x['machine_value']: str(x['english_name']) for x in v}
 
         return field_choices
+
+# We do this here so we can pass the model in along with the follow arguments
+reversion.register(Gloss,follow=['wordclasses','strong_handshape'])
 
 
 class GlossURL(models.Model):

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -425,18 +425,6 @@ $('#id_comment').atwho({
                     <td class="edit edit_list_check" id="wordclass">{{gloss.wordclasses.all|join:", "}}</td>
                 </tr>
 
-                <tr>
-                    <th>{% blocktrans %}Sign number:{% endblocktrans %}</th>
-                    <td id='sign-number'>{{gloss.id}}</td>
-                </tr>
-                <tr>
-                    <th>{% blocktrans %}Film batch:{% endblocktrans %}</th>
-                    <td class="edit edit_text" id='filmbatch'>{{gloss.filmbatch}}</td>
-                </tr>
-                <tr>
-                    <th>{% blocktrans %}Concise:{% endblocktrans %}</th>
-                    <td id="concise">{{ gloss.concise }}</td>
-                </tr>
                 {# Translators: Information about a Gloss #}
                 <!-- {# Removed Dialect for now, uncomment these lines if you want to show dialect #}
                 <tr>

--- a/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
@@ -4,71 +4,84 @@
 {% load static %}
 {% load comments %}
 
-<table class='table table-condensed'>
-    <tr>
-        <th>{% blocktrans %}Created:{% endblocktrans %}</th>
-        <td id='created'>{% if gloss.created_at %}<span class="glyphicon glyphicon-time" aria-hidden="true"></span> <em>{{ gloss.created_at|date:'Y-m-d H:i' }}</em> <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{ gloss.created_by.username }}{% endif %}</td>
-    </tr>
-    <tr>
-        <th>{% blocktrans %}Updated:{% endblocktrans %}</th>
-        <td id='updated'>{% if gloss.updated_at %}
-            <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <em>{{ gloss.updated_at|date:'Y-m-d H:i' }}</em> <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{ gloss.updated_by.username }}
-            {% if request.user.is_staff %}
-            <!-- Modal trigger -->
-            <button type="button" class="btn btn-default" data-toggle="modal" data-target="#modalChangeHistory">
-              <span class="glyphicon glyphicon glyphicon-list-alt" aria-hidden="true"></span>
-                {% blocktrans %}Show complete history{% endblocktrans %}
-            </button>
+{# Tabs nav bar #}
+<ul class="nav nav-tabs" role="tablist">
+    <li class="active"><a href="#revision_history_history_tab" role="tab" data-toggle="tab">Changes</a></li>
+    <li><a href="#revision_history_comments_tab" role="tab" data-toggle="tab">Comments</a></li>
+</ul>
 
-            <!-- Modal -->
-            <div class="modal fade" id="modalChangeHistory" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-              <div class="modal-dialog modal-lg" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="myModalLabel">{% blocktrans %}Change history for{% endblocktrans %} {{gloss}}</h4>
-                  </div>
-                  <div class="modal-body">
-                    <p>
-                        {% blocktrans %}This is a list of some historical changes made to this Gloss.
-                        By clicking the link, you will be taken to the admin site and shown the state of
-                        this gloss at the chosen time.{% endblocktrans %}
-                        <strong>{% blocktrans %}Do not save the changes,
-                        unless you want to restore the older version of this Gloss!{% endblocktrans %}
-                        </strong>
-                    </p>
-                    <ul class="">
-                    {% for version in revisions %}
-                        <li><a href="{% url 'admin:dictionary_gloss_revision' gloss.pk version.pk %}">
-                            <span class="glyphicon glyphicon-time" aria-hidden="true"></span>
-                            {{version.revision.date_created|date:'Y-m-d H:i'}}
-                            <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-                            {{version.revision.user.username }}
-                            {{version.revision.comment}} |
-                            {% if version.data_added or version.data_removed %}{% blocktrans %}Gloss fields:{% endblocktrans %}{% endif %}
-                            {% if version.data_added %}<span style="color:green;">+{{version.data_added}}</span>{% endif %}
-                            {% if version.data_removed %}<span style="color:red;">-{{version.data_removed}}</span>{% endif %}
-                            {% if version.translations_added or version.translations_removed %}{% blocktrans %}Translations:{% endblocktrans %}{% endif %}
-                            {% if version.translations_added %}<span style="color:green;">{{version.translations_added}}</span>{% endif %}
-                            {% if version.translations_removed %}<span style="color:red;">{{version.translations_removed}}</span>{% endif %}
-                        </a></li>
+{# Tabs wrapper #}
+<div class="tab-content">
+
+    {# Tab: Revision History #}
+    <div class="tab-pane active" id="revision_history_history_tab">
+        <table class='table table-condensed'>
+            <tr>
+                <th>{% blocktrans %}Created:{% endblocktrans %}</th>
+                <td id='created'>{% if gloss.created_at %}<span class="glyphicon glyphicon-time" aria-hidden="true"></span> <em>{{ gloss.created_at|date:'Y-m-d H:i' }}</em> <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{ gloss.created_by.username }}{% endif %}</td>
+            </tr>
+            <tr>
+                <th>{% blocktrans %}Updated:{% endblocktrans %}</th>
+                <td id='updated'>{% if gloss.updated_at %}
+                    <span class="glyphicon glyphicon-time" aria-hidden="true"></span> <em>{{ gloss.updated_at|date:'Y-m-d H:i' }}</em> <span class="glyphicon glyphicon-user" aria-hidden="true"></span> {{ gloss.updated_by.username }}
+                    {% if request.user.is_staff %}
+
+                    <hr style="border-top-color:#C0C0C0;margin-bottom:10px;">
+
+                    <div>
+                    <h4>{% blocktrans %}Change history for{% endblocktrans %} <strong>{{gloss}}</strong></h4>
+                    </div>
+                    <div>
+                    <table class='table table-condensed'>
+                        <tr>
+                            <th>{% blocktrans %}User{% endblocktrans %}</th>
+                            <th>{% blocktrans %}Time{% endblocktrans %}</th>
+                            <th>{% blocktrans %}Field{% endblocktrans %}</th>
+                            <th>{% blocktrans %}Old value{% endblocktrans %}</th>
+                            <th>{% blocktrans %}New value{% endblocktrans %}</th>
+                        </tr>
+                        {% for revision_username,revision_time,revision_field_verbosename,revision_old,revision_new in revisions %}
+                        <tr>
+                            {# User #}
+                            <td>
+                                {{ revision_username }}
+                            </td>
+                            {# Time - format: June 22, 2022, 4:06 p.m. #}
+                            <td>
+                                {{ revision_time|date:'F j, Y, g:i a' }}
+                            </td>
+                            {# Field (verbose name) #}
+                            <td>
+                                {{ revision_field_verbosename }}
+                            </td>
+                            {# Old value #}
+                            <td>
+                                {{ revision_old }}
+                            </td>
+                            {# New value #}
+                            <td>
+                                {{ revision_new }}
+                            </td>
+                        </tr>
                         {% endfor %}
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            </div>{% endif %}{% endif %}
-        </td>
-    </tr>
-</table>
+                    </table>
+                    </div>
+                    {% endif %} {# if request.user.is_staff #}
+                    {% endif %} {# if gloss.updated_at #}
+                </td>
+            </tr>
+        </table>
+    </div> {# Tab: Revision History #}
 
-<hr style="border-top-color:#C0C0C0;margin-bottom:10px;">
+    {# Tab: Comments #}
+    <div class="tab-pane" id="revision_history_comments_tab">
+        {% get_comment_count for gloss as comment_count %}
+        <div id="gloss-comments">
+            <h4>{% blocktrans %}Comments{% endblocktrans %} ({{comment_count}})</h4>
+            <div class="well well-md">
+            {% render_comment_list for gloss %}
+            </div>
+        </div>
+    </div> {# Tab: Comments #}
 
-{% get_comment_count for gloss as comment_count %}
-<div id="gloss-comments">
-    <h4>{% blocktrans %}Comments{% endblocktrans %} ({{comment_count}})</h4>
-    <div class="well well-md">
-    {% render_comment_list for gloss %}
-
-    </div>
-</div>
+</div> {# Tabs wrapper #}


### PR DESCRIPTION
The Revision History Tab lives on the Advanced gloss edit page.
It uses the Django Reversion middleware to display changes made to glosses and their relationships.
The createinitialrevisions command from the middleware has been added to the Docker image to catch any newly added models or model revision listeners.
The Revision History tab has two sub-tabs, one for the Changes timeline itself, and one for Comments attached to the gloss.
(This PR also removes duplicate Sign number, Film batch and Concise fields that have returned at some point via a reversion.)

Changes sub-tab
![image](https://user-images.githubusercontent.com/82071930/178196678-eb7a11bb-be55-4a74-a038-683f5fbf1553.png)

Comments sub-tab
![image](https://user-images.githubusercontent.com/82071930/178196735-31dd1188-9e35-45c5-830f-7285e1f90825.png)

Video of the page in action
https://user-images.githubusercontent.com/82071930/178196782-9d1b4123-3875-44d9-848e-28bda8051825.mp4


