### PR TITLE
N2-122: Succeed account confirmation if the user is already activated

### DIFF
--- a/signbank/customregistration/views.py
+++ b/signbank/customregistration/views.py
@@ -1,0 +1,12 @@
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.encoding import force_str
+from django_registration.backends.activation import views
+
+
+class ActivationView(views.ActivationView):
+	def render_to_response(self, context_data):
+		if context_data['activation_error']['code'] == 'already_activated':
+			return HttpResponseRedirect(reverse('django_registration_activation_complete'))
+		else:
+			return super(ActivationView, self).render_to_response(context_data)

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -1,23 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.urls import path, re_path, include
-from django.contrib.auth.decorators import permission_required, login_required
-from django.contrib import admin
-from django.conf import settings
-from django.contrib.sitemaps.views import sitemap
-
-# Views
-from django_registration.backends.activation.views import RegistrationView
-from .dictionary.adminviews import GlossListView
-from .tools import infopage
-from django.contrib.flatpages import views as flatpages_views
-from .comments import edit_comment, latest_comments, latest_comments_page, CommentListView, remove_tag
 import notifications.urls
-from .sitemaps import GlossSitemap, SignbankFlatPageSiteMap, StaticViewSitemap
-from .editorial_queue import get_queue_items
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.flatpages import views as flatpages_views
+from django.contrib.sitemaps.views import sitemap
+from django.urls import include, path, re_path
+# Views
+from django.views.generic.base import TemplateView
+from django_registration.backends.activation.views import RegistrationView
+
+from .comments import (CommentListView, edit_comment, latest_comments,
+                       latest_comments_page, remove_tag)
 # Forms
 from .customregistration.forms import CustomUserForm
+from .customregistration.views import ActivationView
+from .dictionary.adminviews import GlossListView
+from .editorial_queue import get_queue_items
+from .sitemaps import GlossSitemap, SignbankFlatPageSiteMap, StaticViewSitemap
+from .tools import infopage
 
 # Application namespace
 app_name = 'signbank'
@@ -27,48 +30,63 @@ urlpatterns = [
     path('', flatpages_views.flatpage, {'url': '/'}, name='root_page'),
 
     path('sitemap.xml', sitemap, {'sitemaps': {'flatpages': SignbankFlatPageSiteMap,
-                                                  'static': StaticViewSitemap,
-                                                  'gloss': GlossSitemap, }},
-        name='django.contrib.sitemaps.views.sitemap'),
+                                               'static': StaticViewSitemap,
+                                               'gloss': GlossSitemap, }},
+         name='django.contrib.sitemaps.views.sitemap'),
 
     # This allows to change the translations site language
     path('i18n/', include('django.conf.urls.i18n')),
 
     # Include dictionary/, and video/ urls
     path('dictionary/',
-        include('signbank.dictionary.urls', namespace='dictionary')),
+         include('signbank.dictionary.urls', namespace='dictionary')),
     path('video/', include('signbank.video.urls', namespace='video')),
 
     # We used to have this url, keeping it in order to support old urls.
     path('signs/search/', permission_required('dictionary.search_gloss')(GlossListView.as_view()),
-        name='sign_search'),
+         name='sign_search'),
 
     # Registration urls for login, logout, registration, activation etc.
-    path('accounts/register/', RegistrationView.as_view(form_class=CustomUserForm), name='django_registration_register',),
+    path(
+        "accounts/activate/complete/",
+        TemplateView.as_view(
+            template_name="django_registration/activation_complete.html"
+        ),
+        name="django_registration_activation_complete",
+    ),
+    path(
+        "accounts/activate/<str:activation_key>/",
+        ActivationView.as_view(),
+        name="django_registration_activate",
+    ),
+    path('accounts/register/', RegistrationView.as_view(form_class=CustomUserForm),
+         name='django_registration_register',),
     path('accounts/', include('django_registration.backends.activation.urls')),
     path('accounts/', include('django.contrib.auth.urls')),
 
     # Django-contrib-comments urls
     path('comments/', include('django_comments.urls')),
     # Custom functionality added to comments app. Comment editing.
-    path('comments/update/<int:id>/', login_required(edit_comment, login_url='/accounts/login/')),
+    path('comments/update/<int:id>/',
+         login_required(edit_comment, login_url='/accounts/login/')),
     # Feed for latest comments.
     path('comments/latest/', permission_required('dictionary.search_gloss')(latest_comments),
-        name='latest_comments'),
+         name='latest_comments'),
     # Page showing feed for latest comments. Count indicates how many comments to show.
     path('comments/latest/<int:count>/', permission_required('dictionary.search_gloss')(latest_comments_page),
-        name='latest_comments_page'),
+         name='latest_comments_page'),
     path('comments/search/', permission_required('dictionary.search_gloss')(CommentListView.as_view()),
-        name='search_comments'),
+         name='search_comments'),
     path('comments/removetag/', permission_required('dictionary.search_gloss')(remove_tag),
-        name='remove-comment-tag'),
+         name='remove-comment-tag'),
 
     # Notifications urls
-    path('inbox/notifications/', include(notifications.urls, namespace='notifications')),
+    path('inbox/notifications/',
+         include(notifications.urls, namespace='notifications')),
 
     # Admin urls
     path('admin/doc/',
-        include('django.contrib.admindocs.urls')),
+         include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
 
     # Summernote urls, Summernote is the WYSIWYG editor currently used in Signbank
@@ -84,6 +102,7 @@ urlpatterns = [
 if settings.DEBUG:
     import debug_toolbar
     from django.conf.urls.static import static
+
     # Add debug_toolbar when DEBUG=True, also add static+media folders when in development.
     # DEBUG should be False when in production!
     urlpatterns += [
@@ -92,5 +111,5 @@ if settings.DEBUG:
         + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # This is a catchall pattern, will try to match the rest of the urls with flatpages.
-urlpatterns += [re_path('(?P<url>.*/)', flatpages_views.flatpage), ]  # Keep this as the last URL in the file!
-
+# Keep this as the last URL in the file!
+urlpatterns += [re_path('(?P<url>.*/)', flatpages_views.flatpage), ]

--- a/templates/django_registration/activation_failed.html
+++ b/templates/django_registration/activation_failed.html
@@ -1,0 +1,10 @@
+{% extends "django_registration/registration_base.html" %}
+{% load i18n %}
+
+{% block bootstrap3_title %}{% blocktrans %}Activation Failed{% endblocktrans %} | {% endblock %}
+
+{% block content %}
+<div class="alert alert-danger" role="alert">
+    <h3>{% trans "Account activation failed:" %} {{activation_error.message}}</h3>
+</div>
+{% endblock %}


### PR DESCRIPTION
This pull request fixes a bug where either the user visits the activation URL twice by accident, or more likely, their email client prefetches the activation URL, causing them to already be activated by the time they get to clicking on the URL.

The fix is to handle the activation error if they have already been activated as a success case. I have also added the failure template, since that fixes the underlying issue first reported here, where the template in case of error was missing.

Demo:

https://user-images.githubusercontent.com/292020/178860077-2170847d-8e06-425b-a5c8-8bca40062d32.mp4


