### PR TITLE
Removing Tag field from advanced gloss page

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_advanced.html
@@ -398,7 +398,6 @@
         {{ formcomment.object_pk }}
         {{ formcomment.timestamp }}
         {{ formcomment.security_hash }}
-        {% bootstrap_field commenttagform.tag %}
         <input type="hidden" name="next" value="{% url 'dictionary:admin_gloss_view' gloss.id %}">
         <button type="submit" class="btn btn-default" id="id_submit_comm">
             {% blocktrans %}Add comment{% endblocktrans %}</button>


### PR DESCRIPTION
JIRA ticket: https://ackama.atlassian.net/browse/N2-162

Removing `Tag` field just after the `Add comment` field on the advanced gloss page. We can use the tags after videos for the use of adding/ removing tags.

![Screenshot from 2022-07-19 14-14-28](https://user-images.githubusercontent.com/5234605/179663682-b6a866f9-a6df-42e2-93f7-1dab13d4bdae.png)

