### PR TITLE
Upgrading Django 3.2.14 to 3.2.15 to fix Reflected File Download vulnerability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.2.14
+django==3.2.15
 django-tagging==0.5.0
 django-reversion==4.0.0
 django-bootstrap3==21.2


### PR DESCRIPTION
See:
https://www.djangoproject.com/weblog/2022/aug/03/security-releases/

Actions tests failed with a warning about a Reflected File Download vulnerability.
3.2.15 addresses this issue.

