### PR TITLE
Github Actions should be run on pull requests and all pushes to master and production, to run tests + deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - production
 jobs:
   check-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A small omission in our Actions config - I had set up production deployments to run, but needed to target that branch for Actions to even run the workflow.