### PR TITLE
Update README.md to report a known issue about views evaluating querysets on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,9 @@ and proper version pinning, but otherwise doesn't have much value.
   so making this mistake will live in the history of NZSL-signbank and FinSL
   forevermore. Ask me how I know.
 - Some Django views (search is known to be like this, but there might be
-  others), evaluate queryset when the view code is loaded, not on every request.
+  others), evaluate querysets when the view code is loaded, not on every request.
   This means that if something that affects the queryset results (for example, field
-  choices, tags, allowedtags, etc) is modified, the view might not 'see' then
+  choices, tags, allowedtags, etc) is modified, the view might not 'see' the
   changes until it is reloaded. If an issue along the lines of a data update not
   showing up in the UI is reported, a good first step is to restart the
   application. On Heroku, this is easily done via `heroku restart`.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ and proper version pinning, but otherwise doesn't have much value.
   changes, ever_). Remember that pull requests cannot be deleted, only closed,
   so making this mistake will live in the history of NZSL-signbank and FinSL
   forevermore. Ask me how I know.
+- Some Django views (search is known to be like this, but there might be
+  others), evaluate queryset when the view code is loaded, not on every request.
+  This means that if something that affects the queryset results (for example, field
+  choices, tags, allowedtags, etc) is modified, the view might not 'see' then
+  changes until it is reloaded. If an issue along the lines of a data update not
+  showing up in the UI is reported, a good first step is to restart the
+  application. On Heroku, this is easily done via `heroku restart`.
 
 ### Differences between NZSL Signbank and FinSL Signbank
 


### PR DESCRIPTION
This is a quick documentation update to clarify an issue that can happen for views that use a queryset that is fetched when the view is loaded, rather than being kept in a function to be called on each use of the view. This can present with a data update made to the underlying queryset's records or table not being present in the UI.

This morning, we've seen this in the search interface, where changes to `AllowedTag` did not update the gloss relation and tag lists on search views until the application was reloaded.