### PR TITLE
NZSL-83: Do not load content page fixtures in non-development environments, since this can overwrite content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ ENV DJANGO_SETTINGS_MODULE=signbank.settings.development
 CMD pip install -r requirements.txt && \
     bin/develop.py migrate --noinput && \
     bin/develop.py createcachetable && \
-    bin/develop.py loaddata signbank/contentpages/fixtures/flatpages_initial_data.json &&\
+    (\
+        (test $DJANGO_SETTINGS_MODULE = 'signbank.settings.development' && \
+        echo "Loading initial content pages..." && \
+        bin/develop.py loaddata signbank/contentpages/fixtures/flatpages_initial_data.json) \
+    || echo "Skipping loading initial content pages") &&\
     bin/develop.py createinitialrevisions &&\
     gunicorn signbank.wsgi --bind=0.0.0.0:${PORT:=8000}
 


### PR DESCRIPTION
This pull request alters the Docker CMD instruction so that content page fixtures are only loaded in the development environment. These page fixtures can otherwise be run manually in other environments, but should not be run every time the container starts, since Django's `loaddata` management comment overwrites existing records' data with the fixture data.

This has caused issues where content has been updated in UAT and production, and then lost when we deploy. 
In the future, we might also consider moving `createinitialrevisions` into this condition as well, since this can take a long time to run and halt startup, but I've left this in place for now since I'm unsure of the impact of trying to start the app with no versions present.
