### PR TITLE
Update django and certifi to resolve osv-detector warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.2.15
+django==3.2.16
 django-tagging==0.5.0
 django-reversion==4.0.0
 django-bootstrap3==21.2
@@ -14,7 +14,7 @@ dj-database-url==0.5.0
 boto3==1.22.8
 django-storages==1.12.1
 psycopg2==2.8.6
-certifi==2022.6.15
+certifi==2022.12.07
 sentry-sdk==1.5.12
 urllib3==1.26.9
 gunicorn==20.1.0


### PR DESCRIPTION
Resolves:

 certifi@2022.6.15 is affected by the following vulnerabilities:
    GHSA-43fp-rhv2-5gv8: Certifi removing TrustCor root certificate (https://github.com/advisories/GHSA-43fp-rhv2-5gv8)
  django@3.2.15 is affected by the following vulnerabilities:
    GHSA-qrw5-5h28-6cmg: Denial-of-service vulnerability in internationalized URLs (https://github.com/advisories/GHSA-qrw5-5h28-6cmg)