### PR TITLE
Fix dependencies

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -3,3 +3,4 @@ ignore:
   - GHSA-gxr4-xjj5-5px2
   - GHSA-jpcq-cgw6-v4j6
   - GHSA-rmxg-73gg-4p98
+  - GHSA-257q-pv89-v3xv # GHSA says affected versions are jQuery v.2.2.0 until v.3.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       "dev": true
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "dev": true
     },
     "node_modules/jquery.caret": {
@@ -124,9 +124,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "dev": true
     },
     "jquery.caret": {
@@ -155,6 +155,7 @@
     },
     "TagManager": {
       "version": "git+ssh://git@github.com/max-favilli/tagmanager.git#b43646ef2f2373facaf21c7acc5e3eea61188d76",
+      "integrity": "sha512-lEtJG3lUjMSjYizCHh5qOo9glfgzkAeooY0NMkFrQqB3PQqb7z8atKE/EB3zLX8ztvrV+Fv1tQWHc7GUCpvQFA==",
       "dev": true,
       "from": "TagManager@git+https://github.com/max-favilli/tagmanager.git",
       "requires": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.2.20
+django==3.2.23
 django-tagging==0.5.0
 django-reversion==4.0.0
 django-bootstrap3==21.2
@@ -15,7 +15,7 @@ boto3==1.22.8
 django-storages==1.12.1
 psycopg2==2.8.6
 certifi==2023.7.22
-sentry-sdk==1.5.12
-urllib3==1.26.17
+urllib3==1.26.18
+sentry-sdk==1.14.0
 gunicorn==20.1.0
 whitenoise==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==3.2.16
+django==3.2.20
 django-tagging==0.5.0
 django-reversion==4.0.0
 django-bootstrap3==21.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ django-storages==1.12.1
 psycopg2==2.8.6
 certifi==2023.7.22
 sentry-sdk==1.5.12
-urllib3==1.26.9
+urllib3==1.26.17
 gunicorn==20.1.0
 whitenoise==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ boto3==1.22.8
 django-storages==1.12.1
 psycopg2==2.8.6
 certifi==2023.7.22
-sentry-sdk==1.5.12
+sentry-sdk==1.14.0
 urllib3==1.26.9
 gunicorn==20.1.0
 whitenoise==6.2.0


### PR DESCRIPTION
This pull request updates django, urllib3, and sentry-sdk on the Python side, and ignores a jQuery CVE on the Javascript side. The good news with the jQuery CVE, is that for **this particular CVE**, I think we're on a sufficiently old version of jQuery so as to not be vulnerable to it. 

This should get us to a green build on master so we can continue with our contributions.