### PR TITLE
NZSL-74 Fix gloss notes field

### DIFF
--- a/signbank/dictionary/tests/test_update.py
+++ b/signbank/dictionary/tests/test_update.py
@@ -358,7 +358,7 @@ class ShareCSVImportTestCase(TestCase):
         gloss = gloss_qs.first()
         self.assertEqual(f"{csv_content['word']}:{gloss.pk}", gloss.idgloss)
         self.assertEqual(f"{maori_words[0]}:{gloss.pk}", gloss.idgloss_mi)
-        # self.assertEqual("", gloss.notes)
+        self.assertEqual("", gloss.notes)
         self.assertEqual(share_importer, gloss.created_by)
         self.assertEqual(share_importer, gloss.updated_by)
         self.assertEqual(csv_content["contributor_username"], gloss.signer.english_name)

--- a/signbank/dictionary/tests/test_update.py
+++ b/signbank/dictionary/tests/test_update.py
@@ -358,7 +358,7 @@ class ShareCSVImportTestCase(TestCase):
         gloss = gloss_qs.first()
         self.assertEqual(f"{csv_content['word']}:{gloss.pk}", gloss.idgloss)
         self.assertEqual(f"{maori_words[0]}:{gloss.pk}", gloss.idgloss_mi)
-        self.assertEqual(csv_content["notes"], gloss.notes)
+        # self.assertEqual("", gloss.notes)
         self.assertEqual(share_importer, gloss.created_by)
         self.assertEqual(share_importer, gloss.updated_by)
         self.assertEqual(csv_content["contributor_username"], gloss.signer.english_name)

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -933,7 +933,6 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     # idgloss will be updated to word:pk in second step
                     idgloss=f"{gloss_data['word']}_row{row_num}",
                     idgloss_mi=gloss_data.get("maori", None),
-                    notes=gloss_data.get("notes", ""),
                     created_by=import_user,
                     updated_by=import_user,
                     exclude_from_ecv=True,


### PR DESCRIPTION
The notes field on the gloss should not be populated during the import from NZSL-Share, notes should only be added as a comment