### PR TITLE
NZSL-71 Fix video used for ready-for-validation export

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -318,15 +318,10 @@ class GlossListView(ListView):
         for gloss_record in csv_queryset:
             row = [gloss_record.idgloss, gloss_record.gloss_main_aggregate]
             # In theory there should only be one video matching the above query, or none.
-            found_video = True
-            for video in gloss_record.validation_videos:
-                if video.is_video:
-                    row.append(video.videofile.storage.public_url(video.videofile.name))
-                    found_video = True
-                    break
-                else:
-                    continue
-            if not found_video:
+            if video := next((v for v in gloss_record.validation_videos if v.is_video), None):
+                row.append(video.videofile.storage.public_url(video.videofile.name))
+            else:
+                row.append("")
                 row.append("")
             writer.writerow(row)
 

--- a/signbank/dictionary/tests/test_adminviews.py
+++ b/signbank/dictionary/tests/test_adminviews.py
@@ -109,7 +109,8 @@ class GlossListViewTestCase(TestCase):
             is_public=True,
             dataset=testgloss.dataset,
             videofile=testfile,
-            video_type=validation_video_type
+            video_type=validation_video_type,
+            title="Main"
         )
 
         tag_id = Tag.objects.filter(name=settings.TAG_READY_FOR_VALIDATION).values_list("pk", flat=True)[0]


### PR DESCRIPTION
There was an issue that the query retrieved the illustration of the gloss, rather than the video, because it was the first item in the queryset.