### PR TITLE
NZSL-78 display validation results

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -780,17 +780,12 @@ class GlossDetailView(DetailView):
             gloss_content_type = ContentType.objects.get_for_model(Gloss)
             share_comments = Comment.objects.filter(content_type=gloss_content_type, object_pk=self.object.pk, is_public=False)
             validation_records = ValidationRecord.objects.filter(gloss=self.object)
-            try:
-                share_validation_aggregation = ShareValidationAggregation.objects.get(gloss=self.object)
-            except ShareValidationAggregation.DoesNotExist:
-                share_validation_aggregation = None
-            except ShareValidationAggregation.MultipleObjectsReturned:
-                share_validation_aggregations = ShareValidationAggregation.objects.filter(
-                    gloss=self.object)
-                share_validation_aggregation = {"agrees": 0, "disagrees": 0}
-                for share_validation in share_validation_aggregations:
-                    share_validation_aggregation["agrees"] += share_validation.agrees
-                    share_validation_aggregation["disagrees"] += share_validation.disagrees
+            share_validation_aggregations = ShareValidationAggregation.objects.filter(
+                gloss=self.object)
+            share_validation_aggregation = {"agrees": 0, "disagrees": 0}
+            for share_validation in share_validation_aggregations:
+                share_validation_aggregation["agrees"] += share_validation.agrees
+                share_validation_aggregation["disagrees"] += share_validation.disagrees
 
             context['share_comments'] = share_comments
             context['validation_records'] = validation_records

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -186,6 +186,7 @@ $('#id_comment').atwho({
     <li class="active"><a href="#gloss_main_edit_tab" role="tab" data-toggle="tab">Edit</a></li>
     <li><a href="#gloss_public_dictionary_tab" role="tab" data-toggle="tab">Public View</a></li>
     <li><a href="#gloss_revision_history_tab" role="tab" data-toggle="tab">Revision History</a></li>
+    <li><a href="#gloss_validation_results_tab" role="tab" data-toggle="tab">Validation Results</a></li>
 </ul>
 
 {# Tabs wrapper #}
@@ -503,6 +504,11 @@ $('#id_comment').atwho({
 {# Tab: gloss editing Revision History pane #}
 <div class="tab-pane" id="gloss_revision_history_tab">
     {% include "dictionary/gloss_revision_history_tab.html" %}
+</div>
+
+{# Tab: gloss validation results pane #}
+<div class="tab-pane" id="gloss_validation_results_tab">
+  {% include "dictionary/gloss_validation_results_tab.html" %}
 </div>
 
 </div>

--- a/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
@@ -8,7 +8,6 @@
 <ul class="nav nav-tabs" role="tablist" xmlns="http://www.w3.org/1999/html">
     <li class="active"><a href="#revision_history_history_tab" role="tab" data-toggle="tab">Changes</a></li>
     <li><a href="#revision_history_comments_tab" role="tab" data-toggle="tab">Comments</a></li>
-    <li><a href="#revision_history_validation_results_tab" role="tab" data-toggle="tab">Validation Results</a></li>
 </ul>
 
 {# Tabs wrapper #}
@@ -86,104 +85,5 @@
         </div>
     </div>
     {# Tab: Comments #}
-
-  {# Tab: Validation Results #}
-    <div class="tab-pane" id="revision_history_validation_results_tab">
-      <div class="panel panel-info top-margin">
-        <!-- Default panel contents -->
-        <div class="panel-heading">Aggregated validation results from NZSL Share and Qualtrics</div>
-        <div class="panel-body">
-          <!-- Table -->
-          <table class="table">
-          <thead>
-            <td></td>
-            <td><span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span></td>
-            <td><span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span></td>
-            <td><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></td>
-          </thead>
-          <tbody>
-            {% if share_validation_aggregation %}
-              <tr>
-                <td>{% blocktrans %}NZSL Share{% endblocktrans %}</td>
-                <td>{{ share_validation_aggregation.agrees }}</td>
-                <td>{{ share_validation_aggregation.disagrees }}</td>
-                <td>-</td>
-              </tr>
-            {% endif %}
-            <tr>
-              <td>{% blocktrans %}Qualtrics{% endblocktrans %}</td>
-              <td>{{ sign_seen_yes }}</td>
-              <td>{{ sign_seen_no }}</td>
-              <td>{{ sign_seen_maybe }}</td>
-            </tr>
-            {% if share_validation_aggregation %}
-              <tr>
-                <td>{% blocktrans %}Total{% endblocktrans %}</td>
-                <td>{{ sign_seen_yes|add:share_validation_aggregation.agrees }}</td>
-                <td>{{ sign_seen_no|add:share_validation_aggregation.disagrees }}</td>
-                <td>{{ sign_seen_maybe }}</td>
-              </tr>
-            {% endif %}
-          </tbody>
-        </table>
-        </div>
-      </div>
-        {#    Qualtrics validation records#}
-        <div>
-          <h4>
-            {% blocktrans %}Validation records{% endblocktrans %} ({{validation_records|length}})
-            {% if validation_records|length > 0 %}
-              <span class="glyphicon glyphicon-chevron-down" aria-hidden="true" data-toggle="collapse" data-target="#validation-records" aria-expanded="false" aria-controls="validation-records"></span>
-            {% endif %}
-          </h4>
-          <div class="collapse" id="validation-records">
-            <dl class="well well-md">
-              {% for record in validation_records %}
-                <dt {% if not forloop.first %}class="top-margin"{% endif %} id="vr_{{ record.id }}">
-                  {% if record.sign_seen == "yes" %}
-                  <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
-                {% elif record.sign_seen == "no" %}
-                  <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span>
-                {% else %}
-                  <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                {% endif %}
-                  &nbsp;{{ record.respondent_first_name }} {{ record.respondent_last_name }}
-                  <span class="normal-font">(ResponseId: {{ record.response_id }})</span>
-                </dt>
-                <dd>
-                  {% if record.comment %}
-                    <div>
-                      <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;{{ record.comment }}
-                    </div>
-                  {% endif %}
-                </dd>
-              {% endfor %}
-            </dl>
-          </div>
-        </div>
-        {#    NZSL Share comments#}
-        <div>
-            <h4>
-              {% blocktrans %}NZSL Share Comments{% endblocktrans %} ({{share_comments|length}})
-              {% if share_comments|length > 0 %}
-                &nbsp;<span class="glyphicon glyphicon-chevron-down" data-toggle="collapse" data-target="#share-comments" aria-expanded="false" aria-controls="share-comments" aria-hidden="true"></span>
-              {% endif %}
-            </h4>
-            <div id="share-comments" class="collapse">
-              {# snippet copied from the django-comments list template #}
-              <dl class="well well-md">
-                {% for comment in share_comments %}
-                  <dt {% if not forloop.first %}class="top-margin"{% endif %} id="c{{ comment.id }}">
-                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
-                    &nbsp;{{ comment.user_name }}
-                  </dt>
-                  <dd>
-                    <p>{{ comment.comment }}</p>
-                  </dd>
-                {% endfor %}
-              </dl>
-            </div>
-        </div>
-    </div> {# Tab: Comments #}
 
 </div> {# Tabs wrapper #}

--- a/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_revision_history_tab.html
@@ -5,9 +5,10 @@
 {% load comments %}
 
 {# Tabs nav bar #}
-<ul class="nav nav-tabs" role="tablist">
+<ul class="nav nav-tabs" role="tablist" xmlns="http://www.w3.org/1999/html">
     <li class="active"><a href="#revision_history_history_tab" role="tab" data-toggle="tab">Changes</a></li>
     <li><a href="#revision_history_comments_tab" role="tab" data-toggle="tab">Comments</a></li>
+    <li><a href="#revision_history_validation_results_tab" role="tab" data-toggle="tab">Validation Results</a></li>
 </ul>
 
 {# Tabs wrapper #}
@@ -71,7 +72,8 @@
                 </td>
             </tr>
         </table>
-    </div> {# Tab: Revision History #}
+    </div>
+    {# Tab: Revision History #}
 
     {# Tab: Comments #}
     <div class="tab-pane" id="revision_history_comments_tab">
@@ -80,6 +82,106 @@
             <h4>{% blocktrans %}Comments{% endblocktrans %} ({{comment_count}})</h4>
             <div class="well well-md">
             {% render_comment_list for gloss %}
+            </div>
+        </div>
+    </div>
+    {# Tab: Comments #}
+
+  {# Tab: Validation Results #}
+    <div class="tab-pane" id="revision_history_validation_results_tab">
+      <div class="panel panel-info top-margin">
+        <!-- Default panel contents -->
+        <div class="panel-heading">Aggregated validation results from NZSL Share and Qualtrics</div>
+        <div class="panel-body">
+          <!-- Table -->
+          <table class="table">
+          <thead>
+            <td></td>
+            <td><span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span></td>
+            <td><span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span></td>
+            <td><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></td>
+          </thead>
+          <tbody>
+            {% if share_validation_aggregation %}
+              <tr>
+                <td>{% blocktrans %}NZSL Share{% endblocktrans %}</td>
+                <td>{{ share_validation_aggregation.agrees }}</td>
+                <td>{{ share_validation_aggregation.disagrees }}</td>
+                <td>-</td>
+              </tr>
+            {% endif %}
+            <tr>
+              <td>{% blocktrans %}Qualtrics{% endblocktrans %}</td>
+              <td>{{ sign_seen_yes }}</td>
+              <td>{{ sign_seen_no }}</td>
+              <td>{{ sign_seen_maybe }}</td>
+            </tr>
+            {% if share_validation_aggregation %}
+              <tr>
+                <td>{% blocktrans %}Total{% endblocktrans %}</td>
+                <td>{{ sign_seen_yes|add:share_validation_aggregation.agrees }}</td>
+                <td>{{ sign_seen_no|add:share_validation_aggregation.disagrees }}</td>
+                <td>{{ sign_seen_maybe }}</td>
+              </tr>
+            {% endif %}
+          </tbody>
+        </table>
+        </div>
+      </div>
+        {#    Qualtrics validation records#}
+        <div>
+          <h4>
+            {% blocktrans %}Validation records{% endblocktrans %} ({{validation_records|length}})
+            {% if validation_records|length > 0 %}
+              <span class="glyphicon glyphicon-chevron-down" aria-hidden="true" data-toggle="collapse" data-target="#validation-records" aria-expanded="false" aria-controls="validation-records"></span>
+            {% endif %}
+          </h4>
+          <div class="collapse" id="validation-records">
+            <dl class="well well-md">
+              {% for record in validation_records %}
+                <dt {% if not forloop.first %}class="top-margin"{% endif %} id="vr_{{ record.id }}">
+                  {% if record.sign_seen == "yes" %}
+                  <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
+                {% elif record.sign_seen == "no" %}
+                  <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span>
+                {% else %}
+                  <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                {% endif %}
+                  &nbsp;{{ record.respondent_first_name }} {{ record.respondent_last_name }}
+                  <span class="normal-font">(ResponseId: {{ record.response_id }})</span>
+                </dt>
+                <dd>
+                  {% if record.comment %}
+                    <div>
+                      <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;{{ record.comment }}
+                    </div>
+                  {% endif %}
+                </dd>
+              {% endfor %}
+            </dl>
+          </div>
+        </div>
+        {#    NZSL Share comments#}
+        <div>
+            <h4>
+              {% blocktrans %}NZSL Share Comments{% endblocktrans %} ({{share_comments|length}})
+              {% if share_comments|length > 0 %}
+                &nbsp;<span class="glyphicon glyphicon-chevron-down" data-toggle="collapse" data-target="#share-comments" aria-expanded="false" aria-controls="share-comments" aria-hidden="true"></span>
+              {% endif %}
+            </h4>
+            <div id="share-comments" class="collapse">
+              {# snippet copied from the django-comments list template #}
+              <dl class="well well-md">
+                {% for comment in share_comments %}
+                  <dt {% if not forloop.first %}class="top-margin"{% endif %} id="c{{ comment.id }}">
+                    <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+                    &nbsp;{{ comment.user_name }}
+                  </dt>
+                  <dd>
+                    <p>{{ comment.comment }}</p>
+                  </dd>
+                {% endfor %}
+              </dl>
             </div>
         </div>
     </div> {# Tab: Comments #}

--- a/signbank/dictionary/templates/dictionary/gloss_validation_results_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_validation_results_tab.html
@@ -1,0 +1,122 @@
+{% load stylesheet %}
+{% load bootstrap3 %}
+{% load i18n %}
+{% load static %}
+{% load comments %}
+
+
+{# Tabs wrapper #}
+{% if validation_records or share_validation_aggregation %}
+  <div class="panel panel-info top-margin">
+    <!-- Default panel contents -->
+    <div class="panel-heading">Aggregated validation results from NZSL Share and Validation Survey</div>
+    <div class="panel-body">
+      <!-- Table -->
+      <table class="table">
+      <thead>
+        <td></td>
+        <td><span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span></td>
+        <td><span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span></td>
+        <td><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></td>
+        <td class="info">{% blocktrans %}Total{% endblocktrans %}</td>
+      </thead>
+      <tbody>
+        {% if share_validation_aggregation %}
+          <tr>
+            <td>{% blocktrans %}NZSL Share{% endblocktrans %}</td>
+            <td>{{ share_validation_aggregation.agrees }}</td>
+            <td>{{ share_validation_aggregation.disagrees }}</td>
+            <td>-</td>
+            <td class="info">{{ share_validation_aggregation.agrees|add:share_validation_aggregation.disagrees }}</td>
+          </tr>
+        {% endif %}
+        {% if validation_records %}
+          <tr>
+            <td>{% blocktrans %}Validation Survey{% endblocktrans %}</td>
+            <td>{{ sign_seen_yes }}</td>
+            <td>{{ sign_seen_no }}</td>
+            <td>{{ sign_seen_maybe }}</td>
+            <td class="info">{{ sign_seen_yes|add:sign_seen_no|add:sign_seen_maybe }}</td>
+          </tr>
+        {% endif %}
+        {% if validation_records and share_validation_aggregation %}
+          <tr class="info">
+            <td>{% blocktrans %}Total{% endblocktrans %}</td>
+            <td>{{ sign_seen_yes|add:share_validation_aggregation.agrees }}</td>
+            <td>{{ sign_seen_no|add:share_validation_aggregation.disagrees }}</td>
+            <td>{{ sign_seen_maybe }}</td>
+            <td><strong>
+              {{ sign_seen_yes|add:sign_seen_no|add:sign_seen_maybe|add:share_validation_aggregation.disagrees|add:share_validation_aggregation.agrees|add:share_validation_aggregation.disagrees }}
+            </strong></td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+    </div>
+  </div>
+{% else %}
+  <div class="panel panel-warning top-margin">
+    <!-- Default panel contents -->
+    <div class="panel-heading">No validtion results available for this gloss</div>
+  </div>
+{% endif %}
+{% if validation_records %}
+  {#    Qualtrics validation records#}
+  <div>
+    <h4>
+      {% blocktrans %}Validation records{% endblocktrans %} ({{validation_records|length}})
+      {% if validation_records|length > 0 %}
+        <span class="glyphicon glyphicon-chevron-down" aria-hidden="true" data-toggle="collapse" data-target="#validation-records" aria-expanded="false" aria-controls="validation-records"></span>
+      {% endif %}
+    </h4>
+    <div class="collapse" id="validation-records">
+      <dl class="well well-md">
+        {% for record in validation_records %}
+          <dt {% if not forloop.first %}class="top-margin"{% endif %} id="vr_{{ record.id }}">
+            {% if record.sign_seen == "yes" %}
+            <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
+          {% elif record.sign_seen == "no" %}
+            <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span>
+          {% else %}
+            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+          {% endif %}
+            &nbsp;{{ record.respondent_first_name }} {{ record.respondent_last_name }}
+            <span class="normal-font">(ResponseId: {{ record.response_id }})</span>
+          </dt>
+          <dd>
+            {% if record.comment %}
+              <div>
+                <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>&nbsp;{{ record.comment }}
+              </div>
+            {% endif %}
+          </dd>
+        {% endfor %}
+      </dl>
+    </div>
+  </div>
+{% endif %}
+{% if share_comments %}
+  {#    NZSL Share comments#}
+  <div>
+      <h4>
+        {% blocktrans %}NZSL Share Comments{% endblocktrans %} ({{share_comments|length}})
+        {% if share_comments|length > 0 %}
+          &nbsp;<span class="glyphicon glyphicon-chevron-down" data-toggle="collapse" data-target="#share-comments" aria-expanded="false" aria-controls="share-comments" aria-hidden="true"></span>
+        {% endif %}
+      </h4>
+      <div id="share-comments" class="collapse">
+        {# snippet copied from the django-comments list template #}
+        <dl class="well well-md">
+          {% for comment in share_comments %}
+            <dt {% if not forloop.first %}class="top-margin"{% endif %} id="c{{ comment.id }}">
+              <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+              &nbsp;{{ comment.user_name }}
+            </dt>
+            <dd>
+              <p>{{ comment.comment }}</p>
+            </dd>
+          {% endfor %}
+        </dl>
+      </div>
+  </div>
+{% endif %}

--- a/signbank/dictionary/templates/dictionary/gloss_validation_results_tab.html
+++ b/signbank/dictionary/templates/dictionary/gloss_validation_results_tab.html
@@ -46,7 +46,7 @@
             <td>{{ sign_seen_no|add:share_validation_aggregation.disagrees }}</td>
             <td>{{ sign_seen_maybe }}</td>
             <td><strong>
-              {{ sign_seen_yes|add:sign_seen_no|add:sign_seen_maybe|add:share_validation_aggregation.disagrees|add:share_validation_aggregation.agrees|add:share_validation_aggregation.disagrees }}
+              {{ sign_seen_yes|add:sign_seen_no|add:sign_seen_maybe|add:share_validation_aggregation.agrees|add:share_validation_aggregation.disagrees }}
             </strong></td>
           </tr>
         {% endif %}

--- a/signbank/static/css/signbank.css
+++ b/signbank/static/css/signbank.css
@@ -373,3 +373,11 @@ div.btn-default > a.dropdown-toggle {
 div.btn-default > a.dropdown-toggle:hover {
     text-decoration: none;
 }
+
+.normal-font {
+    font-weight: normal;
+}
+
+.top-margin {
+    margin-top: 10px;
+}


### PR DESCRIPTION
1. only validation results from Qualtrics survey
<img width="1167" alt="Screenshot 2024-02-07 at 9 52 16 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/5f8495c9-192f-4e20-ad88-7bf4d957f891">
2. only results from NZSL Share
<img width="1156" alt="Screenshot 2024-02-07 at 9 51 38 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/345e22f7-5545-4d0f-af9c-16fa2fe67e21">
3. Results from both Qualtrics survey and NZSL Share
<img width="1169" alt="Screenshot 2024-02-07 at 9 51 27 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/f5c2475a-b9bc-44bf-8ef0-f3a54b036fba">
4. No validation results are available
<img width="1160" alt="Screenshot 2024-02-07 at 9 23 20 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/93e21cdc-d0c5-4835-94c7-f3882f00a7ce">
5. Expanded ValidationRecords from Qualtrics survey (some with and without comments)
<img width="1164" alt="Screenshot 2024-02-07 at 9 59 06 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/e50bfbdc-bbf1-4a17-bdeb-66a6ca4d4dbc">
6. NZSL Share comment section expanded
<img width="1180" alt="Screenshot 2024-02-07 at 9 59 45 am" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/104b79c5-2120-4f2d-b3d5-2666a0e70795">
