### PR TITLE
NZSL-74 video import fix media root settings

### DIFF
--- a/signbank/settings/production.py
+++ b/signbank/settings/production.py
@@ -24,7 +24,7 @@ CACHES = {
 }
 
 #: Absolute filesystem path to the directory that will hold user-uploaded files.
-MEDIA_ROOT = '/media'
+MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
 # URL that handles the media served from MEDIA_ROOT, used for managing stored files.
 # It must end in a slash if set to a non-empty value.
 MEDIA_URL = '/media/'


### PR DESCRIPTION
Previously the `MEDIA_ROOT` settings for prodution have been a hardcoded string, this seems to have caused an issue during the import of gloss videos from NZSL-Share.
```
2024-02-05T04:19:48.129803+00:00 app[web.1]:   File "/usr/local/lib/python3.9/urllib/request.py", line 249, in urlretrieve
2024-02-05T04:19:48.129939+00:00 app[web.1]:     tfp = open(filename, 'wb')
2024-02-05T04:19:48.129976+00:00 app[web.1]: FileNotFoundError: [Errno 2] No such file or directory: '/media/glossvideo/...
```

Now the `MEDIA_ROOT` matches the setting that is used locally in `development.py`