### PR TITLE
NZSL-74 Upload glossvideos to a temporary directory in retrieval task

### DIFF
--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -24,12 +24,22 @@ def move_glossvideo_to_valid_filepath(glossvideo):
     include the video_type (would cause issues with uniqueness), but still adds the pk-folder into
     the name.
 
+    rename_file gives the file a new name of the format {glosspk}-{idgloss}_{videotype}_{pk}{ext}.
+    get_valid_name method on the storage class splits the name between gloss_pk and idgloss,
+    then joins it back together as {gloss_pk}/{glosspk}-{idgloss}_{videotype}_{pk}{ext}, and
+    then joins that with glossvideo. So the required end result is
+    glossvideo/{gloss_pk}/{glosspk}-{idgloss}_{videotype}_{pk}{ext}
+
+    In our case we need to give get_valid_name our filename, which at this point looks like
+    /app/media/temp_dir/{glosspk}-{idgloss}_{unique_name}_{pk}{ext}, so we split at / and give
+    get_valid_name only the last bit.
+
     This step is necessary because we create the videos in bulk, and usually the filename and path
     are updated in the save() step.
     """
     old_file = glossvideo.videofile
     full_new_path = glossvideo.videofile.storage.get_valid_name(
-        glossvideo.videofile.name.split("/")[-1].split("glossvideo.")[-1]
+        glossvideo.videofile.name.split("/")[-1]
     )
     if not glossvideo.videofile.storage.exists(full_new_path):
         # Save the file into the new path.

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -8,7 +8,6 @@ import random
 import re
 import threading
 
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, permission_required
@@ -1065,7 +1064,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     video_url = gloss_data["videos"]
                     extension = video_url[-3:]
                     file_name = (
-                        f"{settings.MEDIA_ROOT}/glossvideo/"
+                        f"glossvideo."
                         f"{gloss.pk}-{gloss.idgloss}_video.{extension}"
                     )
 
@@ -1082,7 +1081,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["illustrations"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"{settings.MEDIA_ROOT}/glossvideo/"
+                            f"glossvideo."
                             f"{gloss.pk}-{gloss.idgloss}_illustration_{i + 1}.{extension}"
                         )
 
@@ -1099,7 +1098,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["usage_examples"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"{settings.MEDIA_ROOT}/glossvideo/"
+                            f"glossvideo."
                             f"{gloss.pk}-{gloss.idgloss}_usageexample_{i + 1}.{extension}"
                         )
 

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -1064,7 +1064,6 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     video_url = gloss_data["videos"]
                     extension = video_url[-3:]
                     file_name = (
-                        f"glossvideo."
                         f"{gloss.pk}-{gloss.idgloss}_video.{extension}"
                     )
 
@@ -1081,7 +1080,6 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["illustrations"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"glossvideo."
                             f"{gloss.pk}-{gloss.idgloss}_illustration_{i + 1}.{extension}"
                         )
 
@@ -1098,7 +1096,6 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["usage_examples"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"glossvideo."
                             f"{gloss.pk}-{gloss.idgloss}_usageexample_{i + 1}.{extension}"
                         )
 


### PR DESCRIPTION
The actual issue may actually have been around the `glossvideo` folder not existing in UAT, so changed how the moving works, but still using MEDIA_ROOT because if the tempdir is outside the media root it causes a SuspiciousFileOperation error.