### PR TITLE
NZSL-74 retrieve glossvideo based on settings

### DIFF
--- a/signbank/settings/production.py
+++ b/signbank/settings/production.py
@@ -24,7 +24,8 @@ CACHES = {
 }
 
 #: Absolute filesystem path to the directory that will hold user-uploaded files.
-MEDIA_ROOT = os.path.join(PROJECT_DIR, 'media')
+# This is expected to be in a S3 bucket.
+MEDIA_ROOT = '/media'
 # URL that handles the media served from MEDIA_ROOT, used for managing stored files.
 # It must end in a slash if set to a non-empty value.
 MEDIA_URL = '/media/'


### PR DESCRIPTION
Try retrieving glossvideo to different temp dirs based on debug setting and storage class. 
Only move glossvideo itself to valid filepath with DEBUG=True

Could also try uploading the file to S3 before creating the glossvideo (after line 79) but not sure if that extra step is neccessary