### PR TITLE
NZSL-74 Move GlossVideo file for both Storage classes

### DIFF
--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -42,24 +42,21 @@ def move_glossvideo_to_valid_filepath(glossvideo):
     are updated in the save() step.
     """
     old_file = glossvideo.videofile
-    if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
-        full_new_path = glossvideo.videofile.storage.get_valid_name(
-            glossvideo.videofile.name.split("/")[-1]
-        )
-        if not glossvideo.videofile.storage.exists(full_new_path):
-            # Save the file into the new path.
-            saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
-            # Set the actual file path to videofile.
-            glossvideo.videofile = saved_file_path
-
+    full_new_path = ""
     if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
         # move from temp folder to root
         full_new_path = os.path.join(glossvideo.videofile.name.split("/")[-1])
-        if not glossvideo.videofile.storage.exists(full_new_path):
-            # Save the file into the new path.
-            saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
-            # Set the actual file path to videofile.
-            glossvideo.videofile = saved_file_path
+    if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
+        # move from temp folder to media root
+        full_new_path = glossvideo.videofile.storage.get_valid_name(
+            glossvideo.videofile.name.split("/")[-1]
+        )
+
+    if not glossvideo.videofile.storage.exists(full_new_path):
+        # Save the file into the new path.
+        saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
+        # Set the actual file path to videofile.
+        glossvideo.videofile = saved_file_path
     return glossvideo
 
 

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -1,3 +1,4 @@
+import os
 from tempfile import TemporaryDirectory
 from typing import TypedDict, List
 from urllib.request import urlretrieve
@@ -24,27 +25,41 @@ def move_glossvideo_to_valid_filepath(glossvideo):
     the name.
 
     rename_file gives the file a new name of the format {glosspk}-{idgloss}_{videotype}_{pk}{ext}.
-    get_valid_name method on the storage class splits the name between gloss_pk and idgloss,
+
+    get_valid_name method on the GlossVideoStorage (non AWS S3 FileStorage) class splits the name between gloss_pk and idgloss,
     then joins it back together as {gloss_pk}/{glosspk}-{idgloss}_{videotype}_{pk}{ext}, and
     then joins that with glossvideo. So the required end result is
     glossvideo/{gloss_pk}/{glosspk}-{idgloss}_{videotype}_{pk}{ext}
 
-    In our case we need to give get_valid_name our filename, which at this point looks like
+    In the GlossVideoStorage (non AWS S3 FileStorage) case we need to give get_valid_name our filename, which at this point looks like
     /app/media/temp_dir/{glosspk}-{idgloss}_{unique_name}_{pk}{ext}, so we split at / and give
     get_valid_name only the last bit.
+
+    For S3Boto3Storage it should be sufficient to move the file out of the temp folder into the
+    root folder as /{glosspk}-{idgloss}_{unique_name}_{pk}{ext}
 
     This step is necessary because we create the videos in bulk, and usually the filename and path
     are updated in the save() step.
     """
     old_file = glossvideo.videofile
-    full_new_path = glossvideo.videofile.storage.get_valid_name(
-        glossvideo.videofile.name.split("/")[-1]
-    )
-    if not glossvideo.videofile.storage.exists(full_new_path):
-        # Save the file into the new path.
-        saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
-        # Set the actual file path to videofile.
-        glossvideo.videofile = saved_file_path
+    if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
+        full_new_path = glossvideo.videofile.storage.get_valid_name(
+            glossvideo.videofile.name.split("/")[-1]
+        )
+        if not glossvideo.videofile.storage.exists(full_new_path):
+            # Save the file into the new path.
+            saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
+            # Set the actual file path to videofile.
+            glossvideo.videofile = saved_file_path
+
+    if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+        # move from temp folder to root
+        full_new_path = os.path.join(glossvideo.videofile.name.split("/")[-1])
+        if not glossvideo.videofile.storage.exists(full_new_path):
+            # Save the file into the new path.
+            saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
+            # Set the actual file path to videofile.
+            glossvideo.videofile = saved_file_path
     return glossvideo
 
 
@@ -92,9 +107,8 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
             is_public=False,
             video_type=video_type
         )
-        if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
-            gloss_video = move_glossvideo_to_valid_filepath(gloss_video)
-        videos_to_create.append(gloss_video)
+
+        videos_to_create.append(move_glossvideo_to_valid_filepath(gloss_video))
 
     GlossVideo.objects.bulk_create(videos_to_create)
 


### PR DESCRIPTION
While the file upload now works for S3 Storage, the file remains in the temporary directory and is hence inaccessible for the app.
So either the file needs to be moved out of the temporary directory for S3 Storage as well (hoping this doesn't cause an SuspiciousFileOpperation error) or it may not need the temporary directory for uploading at all.