### PR TITLE
NZSL-79 validation result CSV export

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -215,6 +215,7 @@ function clearForm(myFormElement) {
                 <ul class="dropdown-menu">
                   <li><a href="{{ request.get_path }}?{% url_parameter_extend request format='CSV-standard' %}">Standard CSV</a></li>
                   <li><a href="{{ request.get_path }}?{% url_parameter_extend request format='CSV-ready-for-validation' %}">Ready for Validation CSV</a></li>
+                  <li><a href="{{ request.get_path }}?{% url_parameter_extend request format='CSV-validation-results' %}">Validation Results CSV</a></li>
                </ul>
               </div>
             {% endif %}


### PR DESCRIPTION
Adds a new CSV export option to the advanced search page.

Glosses tagged `validation:check-results` are exported in this view. 
The headers in the CSV file are:
| header | explanation |
| ------- | ----------- |
| idgloss | The idgloss identifier for the gloss |
| have seen sign - yes | sum of all ValidationRecord objects for the gloss that have `sign_seen=YES` and sum of ShareValidationAggregation objects field `agrees` |
| have seen sign - no | sum of all ValidationRecord objects for the gloss that have `sign_seen=NO` and sum of ShareValidationAggregation objects field `disagrees` |
| have seen sign - not sure | sum of all ValidationRecord objects for the gloss that have `sign_seen=NOT_SURE` |
| total | sum of all ValidationRecord objects for gloss and `agrees` and `disagrees` fields on ShareValidationAggregation objects |
| comments | \| -separated list of all ValidationRecord objects for gloss that have a comment and non-public (indication they have been created in the Share import) Comments for the gloss |