### PR TITLE
NZSL-85 advanced search video display fix

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -245,7 +245,7 @@ function clearForm(myFormElement) {
 <nav aria-label="{% blocktrans %}Page navigation top{% endblocktrans %}">
     {% include "dictionary/paginate.html" %}
 </nav>
-<table class='table table-condensed'>
+<table class='table table-condensed bottom-margin-100'>
     <thead>
         <tr>
             <th>{% blocktrans %}Dataset{% endblocktrans %}</th>

--- a/signbank/static/css/signbank.css
+++ b/signbank/static/css/signbank.css
@@ -381,3 +381,7 @@ div.btn-default > a.dropdown-toggle:hover {
 .top-margin {
     margin-top: 10px;
 }
+
+.bottom-margin-100 {
+    margin-bottom: 100px;
+}


### PR DESCRIPTION
There is not enough space at the bottom of the table with the search results on the advanced search page, so the video popup fails to show for the last 1-2 glosses.
This PR adds some margin to the bottom of the table to add that space for videos to show.