### PR TITLE
NZSL-74 upload to s3 for aws storage

### DIFF
--- a/signbank/dictionary/csv_import.py
+++ b/signbank/dictionary/csv_import.py
@@ -441,7 +441,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     video_url = gloss_data["videos"]
                     extension = video_url[-3:]
                     file_name = (
-                        f"{gloss.pk}-{gloss.idgloss}_video.{extension}"
+                        f"{gloss.pk}-{word_en}.{gloss.pk}_video.{extension}"
                     )
 
                     glossvideo = {
@@ -457,7 +457,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["illustrations"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"{gloss.pk}-{gloss.idgloss}_illustration_{i + 1}.{extension}"
+                            f"{gloss.pk}-{word_en}.{gloss.pk}_illustration_{i + 1}.{extension}"
                         )
 
                         glossvideo = {
@@ -473,7 +473,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                     for i, video_url in enumerate(gloss_data["usage_examples"].split("|")):
                         extension = video_url[-3:]
                         file_name = (
-                            f"{gloss.pk}-{gloss.idgloss}_usageexample_{i + 1}.{extension}"
+                            f"{gloss.pk}-{word_en}.{gloss.pk}_usageexample_{i + 1}.{extension}"
                         )
 
                         glossvideo = {

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -70,11 +70,12 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     temp_dir = TemporaryDirectory(dir=settings.MEDIA_ROOT)
 
     s3 = boto3.client("s3")
+    s3_storage_used = settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage"
 
     for video in video_details:
         retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"
 
-        if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+        if s3_storage_used:
             file, _ = urlretrieve(
                 retrieval_url,
                 video["file_name"]
@@ -107,7 +108,7 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
             video_type=video_type
         )
 
-        if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
+        if not s3_storage_used:
             gloss_video = move_glossvideo_to_valid_filepath(gloss_video)
         videos_to_create.append(gloss_video)
 

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -1,3 +1,4 @@
+import boto3
 import os
 from tempfile import TemporaryDirectory
 from typing import TypedDict, List
@@ -35,23 +36,13 @@ def move_glossvideo_to_valid_filepath(glossvideo):
     /app/media/temp_dir/{glosspk}-{idgloss}_{unique_name}_{pk}{ext}, so we split at / and give
     get_valid_name only the last bit.
 
-    For S3Boto3Storage it should be sufficient to move the file out of the temp folder into the
-    root folder as /{glosspk}-{idgloss}_{unique_name}_{pk}{ext}
-
     This step is necessary because we create the videos in bulk, and usually the filename and path
     are updated in the save() step.
     """
     old_file = glossvideo.videofile
-    full_new_path = ""
-    if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
-        # move from temp folder to root
-        full_new_path = os.path.join(glossvideo.videofile.name.split("/")[-1])
-    if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
-        # move from temp folder to media root
-        full_new_path = glossvideo.videofile.storage.get_valid_name(
-            glossvideo.videofile.name.split("/")[-1]
-        )
-
+    full_new_path = glossvideo.videofile.storage.get_valid_name(
+        glossvideo.videofile.name.split("/")[-1]
+    )
     if not glossvideo.videofile.storage.exists(full_new_path):
         # Save the file into the new path.
         saved_file_path = glossvideo.videofile.storage.save(full_new_path, old_file)
@@ -77,16 +68,27 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     videos_to_create = []
 
     temp_dir = TemporaryDirectory(dir=settings.MEDIA_ROOT)
-    if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
-        temp_dir = TemporaryDirectory()
+
+    s3 = boto3.client("s3")
 
     for video in video_details:
         retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"
-        file_name = f"{temp_dir.name}/{video['file_name']}"
-        file, _ = urlretrieve(
-            retrieval_url,
-            file_name
-        )
+
+        if settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+            file, _ = urlretrieve(
+                retrieval_url,
+                video["file_name"]
+            )
+            s3.upload_file(
+                file, settings.AWS_STORAGE_BUCKET_NAME, video["file_name"]
+            )
+        else:
+            file_name = f"{temp_dir.name}/{video['file_name']}"
+            file, _ = urlretrieve(
+                retrieval_url,
+                file_name
+            )
+
         gloss = Gloss.objects.get(pk=video["gloss_pk"])
 
         # change video type to main for illustrations
@@ -105,7 +107,9 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
             video_type=video_type
         )
 
-        videos_to_create.append(move_glossvideo_to_valid_filepath(gloss_video))
+        if settings.GLOSS_VIDEO_FILE_STORAGE != "storages.backends.s3boto3.S3Boto3Storage":
+            gloss_video = move_glossvideo_to_valid_filepath(gloss_video)
+        videos_to_create.append(gloss_video)
 
     GlossVideo.objects.bulk_create(videos_to_create)
 


### PR DESCRIPTION
Last attempted fix did not work because the file did not end up being moved, so stayed in the temp folder and was inaccessible in UAT.

New approach uploads the file to S3 after it is retrieved, rather than trying to move it around (if it ever even uploaded in the first place).

Approach has been tested locally connected to AWS S3 storage