### PR TITLE
NZSL-182 Part 2:  NZSL Share CSV import skips rows with Share IDs associated with existing glosses

### DIFF
--- a/signbank/dictionary/csv_import.py
+++ b/signbank/dictionary/csv_import.py
@@ -158,6 +158,7 @@ def confirm_import_gloss_csv(request):
 
 
 share_csv_header_list = [
+    "id",
     "word",
     "maori",
     "secondary",
@@ -219,10 +220,21 @@ def import_nzsl_share_gloss_csv(request):
             delimiter=",",
             quotechar='"'
         )
+
+        skipped_existing_glosses = []
+        existing_nzsl_share_ids = set(
+            Gloss.objects.exclude(nzsl_share_id__exact="").values_list(
+                "nzsl_share_id", flat=True
+            )
+        )
+
         for row in glossreader:
             if glossreader.line_num == 1:
                 continue
-            new_glosses.append(row)
+            if row["id"] not in existing_nzsl_share_ids:
+                new_glosses.append(row)
+            else:
+                skipped_existing_glosses.append(row)
     except csv.Error as e:
         # Can't open file, remove session variables
         request.session.pop("dataset_id", None)
@@ -242,8 +254,11 @@ def import_nzsl_share_gloss_csv(request):
     request.session["glosses_new"] = new_glosses
 
     return render(request, "dictionary/import_nzsl_share_gloss_csv_confirmation.html",
-                  {"glosses_new": new_glosses,
-                   "dataset": dataset, })
+                  {
+                      "glosses_new": new_glosses,
+                      "dataset": dataset,
+                      "skipped_existing_glosses": skipped_existing_glosses
+                  })
 
 
 @login_required
@@ -262,189 +277,207 @@ def confirm_import_nzsl_share_gloss_csv(request):
         # Set a message to be shown so that the user knows what is going on.
         messages.add_message(request, messages.WARNING, _("Cancelled adding CSV data."))
         return HttpResponseRedirect(reverse("dictionary:import_nzsl_share_gloss_csv"))
+    elif not "confirm" in request.POST:
+        return HttpResponseRedirect(reverse("dictionary:import_nzsl_share_gloss_csv"))
 
-    elif "confirm" in request.POST:
-        glosses_added = []
-        dataset = None
-        translations = []
-        comments = []
-        videos = []
-        new_glosses = {}
-        bulk_create_gloss = []
-        bulk_update_glosses = []
-        bulk_semantic_fields = []
-        bulk_tagged_items = []
-        contributors = []
-        bulk_share_validation_aggregations = []
+    glosses_added = []
+    dataset = None
+    translations = []
+    comments = []
+    videos = []
+    new_glosses = {}
+    bulk_create_gloss = []
+    bulk_update_glosses = []
+    bulk_semantic_fields = []
+    bulk_tagged_items = []
+    contributors = []
+    bulk_share_validation_aggregations = []
 
-        if "glosses_new" and "dataset_id" in request.session:
-            dataset = Dataset.objects.get(id=request.session["dataset_id"])
-            language_en = Language.objects.get(name="English")
-            language_mi = Language.objects.get(name="Māori")
-            gloss_content_type = ContentType.objects.get_for_model(Gloss)
-            site = Site.objects.get_current()
-            comment_submit_date = datetime.datetime.now(tz=get_current_timezone())
-            semantic_fields = FieldChoice.objects.filter(
-                field="semantic_field"
-            ).values_list("english_name", "pk")
-            semantic_fields_dict = {field[0]: field[1] for field in semantic_fields}
-            signers = FieldChoice.objects.filter(field="signer")
-            signer_dict = {signer.english_name: signer for signer in signers}
-            existing_machine_values = [mv for mv in
-                                       FieldChoice.objects.all().values_list("machine_value",
-                                                                             flat=True)]
-            not_public_tag = Tag.objects.get(name="not public")
-            nzsl_share_tag = Tag.objects.get(name="nzsl-share")
-            import_user = User.objects.get(
-                username="nzsl_share_importer",
-                first_name="Importer",
-                last_name="NZSL Share",
-            )
+    if "glosses_new" and "dataset_id" in request.session:
+        dataset = Dataset.objects.get(id=request.session["dataset_id"])
+        language_en = Language.objects.get(name="English")
+        language_mi = Language.objects.get(name="Māori")
+        gloss_content_type = ContentType.objects.get_for_model(Gloss)
+        site = Site.objects.get_current()
+        comment_submit_date = datetime.datetime.now(tz=get_current_timezone())
+        semantic_fields = FieldChoice.objects.filter(
+            field="semantic_field"
+        ).values_list("english_name", "pk")
+        semantic_fields_dict = {field[0]: field[1] for field in semantic_fields}
+        signers = FieldChoice.objects.filter(field="signer")
+        signer_dict = {signer.english_name: signer for signer in signers}
+        existing_machine_values = [
+            mv for mv in FieldChoice.objects.all().values_list("machine_value", flat=True)
+        ]
+        not_public_tag = Tag.objects.get(name="not public")
+        nzsl_share_tag = Tag.objects.get(name="nzsl-share")
+        import_user = User.objects.get(
+            username="nzsl_share_importer",
+            first_name="Importer",
+            last_name="NZSL Share",
+        )
 
-            for row_num, gloss_data in enumerate(request.session["glosses_new"]):
-                # will iterate over these glosses again after bulk creating
-                # and to ensure we get the correct gloss_data for words that appear multiple
-                # times we'll use the row_num as the identifier for the gloss data
-                new_glosses[str(row_num)] = gloss_data
-                bulk_create_gloss.append(Gloss(
-                    dataset=dataset,
-                    # need to make idgloss unique in dataset,
-                    # but gloss word can appear in multiple rows, so
-                    # idgloss will be updated to word:pk in second step
-                    idgloss=f"{gloss_data['word']}_row{row_num}",
-                    idgloss_mi=gloss_data.get("maori", None),
-                    created_by=import_user,
-                    updated_by=import_user,
-                    exclude_from_ecv=True,
-                ))
-                contributors.append(gloss_data["contributor_username"])
+        for row_num, gloss_data in enumerate(request.session["glosses_new"]):
+            # will iterate over these glosses again after bulk creating
+            # and to ensure we get the correct gloss_data for words that appear multiple
+            # times we'll use the row_num as the identifier for the gloss data
+            new_glosses[str(row_num)] = gloss_data
+            bulk_create_gloss.append(Gloss(
+                dataset=dataset,
+                nzsl_share_id=gloss_data["id"],
+                # need to make idgloss unique in dataset,
+                # but gloss word can appear in multiple rows, so
+                # idgloss will be updated to word:pk in second step
+                idgloss=f"{gloss_data['word']}_row{row_num}",
+                idgloss_mi=gloss_data.get("maori", None),
+                created_by=import_user,
+                updated_by=import_user,
+                exclude_from_ecv=True,
+            ))
+            contributors.append(gloss_data["contributor_username"])
 
-            bulk_created = Gloss.objects.bulk_create(bulk_create_gloss)
+        bulk_created = Gloss.objects.bulk_create(bulk_create_gloss)
 
-            # Create new signers for contributors that do not exist as signers yet
-            contributors = set(contributors)
-            create_signers = []
-            signers = signer_dict.keys()
-            for contributor in contributors:
-                if contributor not in signers:
+        # Create new signers for contributors that do not exist as signers yet
+        contributors = set(contributors)
+        create_signers = []
+        signers = signer_dict.keys()
+        for contributor in contributors:
+            if contributor not in signers:
+                new_machine_value = random.randint(0, 99999999)
+                while new_machine_value in existing_machine_values:
                     new_machine_value = random.randint(0, 99999999)
-                    while new_machine_value in existing_machine_values:
-                        new_machine_value = random.randint(0, 99999999)
-                    existing_machine_values.append(new_machine_value)
-                    create_signers.append(FieldChoice(
-                        field="signer",
-                        english_name=contributor,
-                        machine_value=new_machine_value
-                    ))
-            new_signers = FieldChoice.objects.bulk_create(create_signers)
-            for signer in new_signers:
-                signer_dict[signer.english_name] = signer
+                existing_machine_values.append(new_machine_value)
+                create_signers.append(FieldChoice(
+                    field="signer",
+                    english_name=contributor,
+                    machine_value=new_machine_value
+                ))
+        new_signers = FieldChoice.objects.bulk_create(create_signers)
+        for signer in new_signers:
+            signer_dict[signer.english_name] = signer
 
-            for gloss in bulk_created:
-                word_en, row_num = gloss.idgloss.split("_row")
-                gloss_data = new_glosses[row_num]
+        for gloss in bulk_created:
+            word_en, row_num = gloss.idgloss.split("_row")
+            gloss_data = new_glosses[row_num]
 
-                # get semantic fields for gloss_data topics
-                if gloss_data.get("topic_names", None):
-                    gloss_topics = gloss_data["topic_names"].split("|")
-                    # ignore all signs and All signs
-                    cleaned_gloss_topics = [
-                        x for x in gloss_topics if x not in ["all signs", "All signs"]
-                    ]
-                    add_miscellaneous = False
+            # get semantic fields for gloss_data topics
+            if gloss_data.get("topic_names", None):
+                gloss_topics = gloss_data["topic_names"].split("|")
+                # ignore all signs and All signs
+                cleaned_gloss_topics = [
+                    x for x in gloss_topics if x not in ["all signs", "All signs"]
+                ]
+                add_miscellaneous = False
 
-                    for topic in cleaned_gloss_topics:
-                        if topic in semantic_fields_dict.keys():
-                            bulk_semantic_fields.append(
-                                Gloss.semantic_field.through(
-                                    gloss_id=gloss.id,
-                                    fieldchoice_id=semantic_fields_dict[topic]
-                                )
-                            )
-                        else:
-                            # add the miscellaneous semantic field if a topic does not exist
-                            add_miscellaneous = True
-
-                    if add_miscellaneous:
+                for topic in cleaned_gloss_topics:
+                    if topic in semantic_fields_dict.keys():
                         bulk_semantic_fields.append(
                             Gloss.semantic_field.through(
                                 gloss_id=gloss.id,
-                                fieldchoice_id=semantic_fields_dict["Miscellaneous"]
+                                fieldchoice_id=semantic_fields_dict[topic]
                             )
                         )
+                    else:
+                        # add the miscellaneous semantic field if a topic does not exist
+                        add_miscellaneous = True
 
-                # create GlossTranslations for english and maori words
-                translations.append(GlossTranslations(
-                    gloss=gloss,
-                    language=language_en,
-                    translations=gloss_data["word"],
-                    translations_secondary=gloss_data.get("secondary", None)
-                ))
-                if gloss_data.get("maori", None):
-                    # There is potentially several comma separated maori words
-                    maori_words = gloss_data["maori"].split(", ")
-
-                    # Update idgloss_mi using first maori word, then create translation
-                    gloss.idgloss_mi = f"{maori_words[0]}:{gloss.pk}"
-
-                    translation = GlossTranslations(
-                        gloss=gloss,
-                        language=language_mi,
-                        translations=maori_words[0]
+                if add_miscellaneous:
+                    bulk_semantic_fields.append(
+                        Gloss.semantic_field.through(
+                            gloss_id=gloss.id,
+                            fieldchoice_id=semantic_fields_dict["Miscellaneous"]
+                        )
                     )
-                    if len(maori_words) > 1:
-                        translation.translations_secondary = ", ".join(maori_words[1:])
 
-                    translations.append(translation)
+            # create GlossTranslations for english and maori words
+            translations.append(GlossTranslations(
+                gloss=gloss,
+                language=language_en,
+                translations=gloss_data["word"],
+                translations_secondary=gloss_data.get("secondary", None)
+            ))
+            if gloss_data.get("maori", None):
+                # There is potentially several comma separated maori words
+                maori_words = gloss_data["maori"].split(", ")
 
-                # Prepare new idgloss and signer fields for bulk update
-                gloss.idgloss = f"{word_en}:{gloss.pk}"
-                gloss.signer = signer_dict[gloss_data["contributor_username"]]
-                bulk_update_glosses.append(gloss)
+                # Update idgloss_mi using first maori word, then create translation
+                gloss.idgloss_mi = f"{maori_words[0]}:{gloss.pk}"
 
-                # Create comment for gloss_data notes
-                comments.append(Comment(
-                    content_type=gloss_content_type,
-                    object_pk=gloss.pk,
-                    user_name=gloss_data.get("contributor_username", ""),
-                    comment=gloss_data.get("notes", ""),
-                    site=site,
-                    is_public=False,
-                    submit_date=comment_submit_date
-                ))
-                if gloss_data.get("sign_comments", None):
-                    # create Comments for all gloss_data sign_comments
-                    for comment in gloss_data["sign_comments"].split("|"):
-                        try:
-                            comment_content = comment.split(":")
-                            user_name = comment_content[0]
-                            comment_content = comment_content[1]
-                        except IndexError:
-                            comment_content = comment
-                            user_name = "Unknown"
-                        comments.append(Comment(
-                            content_type=gloss_content_type,
-                            object_pk=gloss.pk,
-                            user_name=user_name,
-                            comment=comment_content,
-                            site=site,
-                            is_public=False,
-                            submit_date=comment_submit_date
-                        ))
-
-                # Add ShareValidationAggregation
-                bulk_share_validation_aggregations.append(ShareValidationAggregation(
+                translation = GlossTranslations(
                     gloss=gloss,
-                    agrees=int(gloss_data["agrees"]),
-                    disagrees=int(gloss_data["disagrees"])
-                ))
+                    language=language_mi,
+                    translations=maori_words[0]
+                )
+                if len(maori_words) > 1:
+                    translation.translations_secondary = ", ".join(maori_words[1:])
 
-                # prep videos, illustrations and usage example for video retrieval
-                if gloss_data.get("videos", None):
-                    video_url = gloss_data["videos"]
+                translations.append(translation)
+
+            # Prepare new idgloss and signer fields for bulk update
+            gloss.idgloss = f"{word_en}:{gloss.pk}"
+            gloss.signer = signer_dict[gloss_data["contributor_username"]]
+            bulk_update_glosses.append(gloss)
+
+            # Create comment for gloss_data notes
+            comments.append(Comment(
+                content_type=gloss_content_type,
+                object_pk=gloss.pk,
+                user_name=gloss_data.get("contributor_username", ""),
+                comment=gloss_data.get("notes", ""),
+                site=site,
+                is_public=False,
+                submit_date=comment_submit_date
+            ))
+            if gloss_data.get("sign_comments", None):
+                # create Comments for all gloss_data sign_comments
+                for comment in gloss_data["sign_comments"].split("|"):
+                    try:
+                        comment_content = comment.split(":")
+                        user_name = comment_content[0]
+                        comment_content = comment_content[1]
+                    except IndexError:
+                        comment_content = comment
+                        user_name = "Unknown"
+                    comments.append(Comment(
+                        content_type=gloss_content_type,
+                        object_pk=gloss.pk,
+                        user_name=user_name,
+                        comment=comment_content,
+                        site=site,
+                        is_public=False,
+                        submit_date=comment_submit_date
+                    ))
+
+            # Add ShareValidationAggregation
+            bulk_share_validation_aggregations.append(ShareValidationAggregation(
+                gloss=gloss,
+                agrees=int(gloss_data["agrees"]),
+                disagrees=int(gloss_data["disagrees"])
+            ))
+
+            # prep videos, illustrations and usage example for video retrieval
+            if gloss_data.get("videos", None):
+                video_url = gloss_data["videos"]
+                extension = video_url[-3:]
+                file_name = (
+                    f"{gloss.pk}-{word_en}.{gloss.pk}_video.{extension}"
+                )
+
+                glossvideo = {
+                    "url": video_url,
+                    "file_name": file_name,
+                    "gloss_pk": gloss.pk,
+                    "video_type": "main",
+                    "version": 0
+                }
+                videos.append(glossvideo)
+
+            if gloss_data.get("illustrations", None):
+                for i, video_url in enumerate(gloss_data["illustrations"].split("|")):
                     extension = video_url[-3:]
                     file_name = (
-                        f"{gloss.pk}-{word_en}.{gloss.pk}_video.{extension}"
+                        f"{gloss.pk}-{word_en}.{gloss.pk}_illustration_{i + 1}.{extension}"
                     )
 
                     glossvideo = {
@@ -452,84 +485,70 @@ def confirm_import_nzsl_share_gloss_csv(request):
                         "file_name": file_name,
                         "gloss_pk": gloss.pk,
                         "video_type": "main",
-                        "version": 0
+                        "version": i
                     }
                     videos.append(glossvideo)
 
-                if gloss_data.get("illustrations", None):
-                    for i, video_url in enumerate(gloss_data["illustrations"].split("|")):
-                        extension = video_url[-3:]
-                        file_name = (
-                            f"{gloss.pk}-{word_en}.{gloss.pk}_illustration_{i + 1}.{extension}"
-                        )
+            if gloss_data.get("usage_examples", None):
+                for i, video_url in enumerate(gloss_data["usage_examples"].split("|")):
+                    extension = video_url[-3:]
+                    file_name = (
+                        f"{gloss.pk}-{word_en}.{gloss.pk}_usageexample_{i + 1}.{extension}"
+                    )
 
-                        glossvideo = {
-                            "url": video_url,
-                            "file_name": file_name,
-                            "gloss_pk": gloss.pk,
-                            "video_type": "main",
-                            "version": i
-                        }
-                        videos.append(glossvideo)
+                    glossvideo = {
+                        "url": video_url,
+                        "file_name": file_name,
+                        "gloss_pk": gloss.pk,
+                        "video_type": f"finalexample{i + 1}",
+                        "version": i
+                    }
+                    videos.append(glossvideo)
 
-                if gloss_data.get("usage_examples", None):
-                    for i, video_url in enumerate(gloss_data["usage_examples"].split("|")):
-                        extension = video_url[-3:]
-                        file_name = (
-                            f"{gloss.pk}-{word_en}.{gloss.pk}_usageexample_{i + 1}.{extension}"
-                        )
+            glosses_added.append(gloss)
 
-                        glossvideo = {
-                            "url": video_url,
-                            "file_name": file_name,
-                            "gloss_pk": gloss.pk,
-                            "video_type": f"finalexample{i + 1}",
-                            "version": i
-                        }
-                        videos.append(glossvideo)
+            bulk_tagged_items.append(TaggedItem(
+                content_type=gloss_content_type,
+                object_id=gloss.pk,
+                tag=nzsl_share_tag
 
-                glosses_added.append(gloss)
+            ))
+            bulk_tagged_items.append(TaggedItem(
+                content_type=gloss_content_type,
+                object_id=gloss.pk,
+                tag=not_public_tag
 
-                bulk_tagged_items.append(TaggedItem(
-                    content_type=gloss_content_type,
-                    object_id=gloss.pk,
-                    tag=nzsl_share_tag
+            ))
 
-                ))
-                bulk_tagged_items.append(TaggedItem(
-                    content_type=gloss_content_type,
-                    object_id=gloss.pk,
-                    tag=not_public_tag
+        # Bulk create entities related to the gloss, and bulk update the glosses' idgloss
+        Comment.objects.bulk_create(comments)
+        GlossTranslations.objects.bulk_create(translations)
+        Gloss.objects.bulk_update(bulk_update_glosses, ["idgloss", "idgloss_mi", "signer"])
+        Gloss.semantic_field.through.objects.bulk_create(bulk_semantic_fields)
+        TaggedItem.objects.bulk_create(bulk_tagged_items)
+        ShareValidationAggregation.objects.bulk_create(bulk_share_validation_aggregations)
 
-                ))
-
-            # Bulk create entities related to the gloss, and bulk update the glosses' idgloss
-            Comment.objects.bulk_create(comments)
-            GlossTranslations.objects.bulk_create(translations)
-            Gloss.objects.bulk_update(bulk_update_glosses, ["idgloss", "idgloss_mi", "signer"])
-            Gloss.semantic_field.through.objects.bulk_create(bulk_semantic_fields)
-            TaggedItem.objects.bulk_create(bulk_tagged_items)
-            ShareValidationAggregation.objects.bulk_create(bulk_share_validation_aggregations)
-
-            # start Thread to process gloss video retrieval in the background
-            t = threading.Thread(
-                target=retrieve_videos_for_glosses,
-                args=[videos],
-                daemon=True
-            )
-            t.start()
-
-            del request.session["glosses_new"]
-            del request.session["dataset_id"]
-
-            # Set a message to be shown so that the user knows what is going on.
-            messages.add_message(request, messages.SUCCESS, _("Glosses were added succesfully."))
-        return render(
-            request, "dictionary/import_nzsl_share_gloss_csv_confirmation.html",
-            {"glosses_added": glosses_added, "dataset": dataset.name}
+        # start Thread to process gloss video retrieval in the background
+        t = threading.Thread(
+            target=retrieve_videos_for_glosses,
+            args=[videos],
+            daemon=True
         )
-    else:
-        return HttpResponseRedirect(reverse("dictionary:import_nzsl_share_gloss_csv"))
+        t.start()
+
+        del request.session["glosses_new"]
+        del request.session["dataset_id"]
+
+        # Set a message to be shown so that the user knows what is going on.
+        messages.add_message(request, messages.SUCCESS, _("Glosses were added succesfully."))
+    return render(
+        request, "dictionary/import_nzsl_share_gloss_csv_confirmation.html",
+        {
+            "glosses_added": glosses_added,
+            "dataset": dataset.name
+        }
+    )
+
 
 
 @login_required

--- a/signbank/dictionary/templates/dictionary/import_nzsl_share_gloss_csv_confirmation.html
+++ b/signbank/dictionary/templates/dictionary/import_nzsl_share_gloss_csv_confirmation.html
@@ -30,6 +30,21 @@
         <input class='btn btn-primary' name='cancel' type='submit' value='{% blocktrans %}Cancel{% endblocktrans %}'>
       </form>
     {% endif %}
+    {% if skipped_existing_glosses %}
+      <div>
+        <h4>{% blocktrans %}Some existing glosses have the following NZSL Share ids already associated to them{% endblocktrans %}</h4>
+        <table class="table">
+          <th>NZSL Share ID</th>
+          <th>Share gloss data</th>
+          {% for gloss_data in skipped_existing_glosses %}
+            <tr>
+              <td>{{ gloss_data.id }}</td>
+              <td>{{ gloss_data.word }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
+    {% endif %}
 
     {% if glosses_added %}
         <h3>{% blocktrans %}The following glosses were added to{% endblocktrans %} <span class="label label-default">{{dataset}}</span></h3>

--- a/signbank/dictionary/tests/test_csv_import.py
+++ b/signbank/dictionary/tests/test_csv_import.py
@@ -63,6 +63,7 @@ class ShareCSVImportTestCase(TestCase):
         assign_perm('view_dataset', self.user, self.dataset)
 
     _csv_content = {
+        "id": "111",
         "word": "Test",
         "maori": "maori, maori 2",
         "secondary": "test",
@@ -123,6 +124,37 @@ class ShareCSVImportTestCase(TestCase):
         session = self.client.session
         self.assertEqual(self.dataset.pk, session["dataset_id"])
         self.assertListEqual([self._csv_content], session["glosses_new"])
+
+    def test_share_ids_existing_on_glosses_are_skipped(self):
+        """
+        Test a csv file which contains a row for which an existing gloss has the share id
+        associated with it is skipped
+        """
+        file_name = "test.csv"
+        csv_content = [copy.deepcopy(self._csv_content), copy.deepcopy(self._csv_content)]
+        csv_content[1]["id"] = "12345"
+        
+        with open(file_name, "w") as file:
+            writer = csv.writer(file)
+            writer.writerow(csv_content[0].keys())
+            for row in csv_content:
+                writer.writerow(row.values())
+        data = open(file_name, "rb")
+        file = SimpleUploadedFile(
+            content=data.read(), name=data.name, content_type="content/multipart"
+        )
+        Gloss.objects.create(dataset=self.dataset, idgloss="Share:11", nzsl_share_id="12345")
+
+        response = self.client.post(
+            reverse('dictionary:import_nzsl_share_gloss_csv'),
+            {"dataset": self.dataset.pk, "file": file},
+            format="multipart"
+        )
+        self.assertEqual(response.status_code, 200)
+        session = self.client.session
+        self.assertEqual(self.dataset.pk, session["dataset_id"])
+        self.assertListEqual([csv_content[0]], session["glosses_new"])
+        self.assertListEqual([csv_content[1]], response.context["skipped_existing_glosses"])
 
     def test_confirmation_view_confirm_gloss_creation(self):
         """


### PR DESCRIPTION
If the CSV file contains rows that have a NZSL Share ID that is already associated with a gloss in Signbank these rows will be skipped. This is displayed to the user before the confirmation step.

**This PR may only be merged after the `id` field has been added to the Signbank CSV export in NZSL Share**

<img width="1176" alt="Screenshot 2024-02-22 at 1 36 28 pm" src="https://github.com/ODNZSL/NZSL-signbank/assets/26726841/fd77d1bf-acab-46b5-8913-bb74306e6043">
