### PR TITLE
Fixes for share import and ready for validation export flows

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -289,7 +289,6 @@ class GlossListView(ListView):
             video_type__field="video_type",
             video_type__english_name="validation",
             videofile__isnull=False,
-            title="Main",
         )
 
         csv_queryset = (

--- a/signbank/dictionary/csv_import.py
+++ b/signbank/dictionary/csv_import.py
@@ -448,7 +448,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                         "url": video_url,
                         "file_name": file_name,
                         "gloss_pk": gloss.pk,
-                        "title": "Main",
+                        "video_type": "main",
                         "version": 0
                     }
                     videos.append(glossvideo)
@@ -464,7 +464,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                             "url": video_url,
                             "file_name": file_name,
                             "gloss_pk": gloss.pk,
-                            "title": "Illustration",
+                            "video_type": "main",
                             "version": i
                         }
                         videos.append(glossvideo)
@@ -480,7 +480,7 @@ def confirm_import_nzsl_share_gloss_csv(request):
                             "url": video_url,
                             "file_name": file_name,
                             "gloss_pk": gloss.pk,
-                            "title": f"finalexample{i + 1}",
+                            "video_type": f"finalexample{i + 1}",
                             "version": i
                         }
                         videos.append(glossvideo)

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -15,7 +15,7 @@ class VideoDetail(TypedDict):
     url: str
     file_name: str
     gloss_pk: int
-    title: str
+    video_type: str
     version: int
 
 
@@ -62,9 +62,20 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     - title
     - version
     """
-    validation_video_type = FieldChoice.objects.filter(field="video_type",
-                                                       english_name="validation").first()
     main_video_type = FieldChoice.objects.filter(field="video_type", english_name="main").first()
+    finalexample_1_video_type = FieldChoice.objects.filter(
+        field="video_type",
+        english_name="finalexample1"
+    ).first()
+    finalexample_2_video_type = FieldChoice.objects.filter(
+        field="video_type",
+        english_name="finalexample2"
+    ).first()
+    video_type_map = {
+        "main": main_video_type,
+        "finalexample1": finalexample_1_video_type,
+        "finalexample2": finalexample_2_video_type
+    }
     videos_to_create = []
 
     temp_dir = TemporaryDirectory(dir=settings.MEDIA_ROOT)
@@ -92,20 +103,14 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
 
         gloss = Gloss.objects.get(pk=video["gloss_pk"])
 
-        # change video type to main for illustrations
-        video_type = validation_video_type
-        if video["title"] == "Illustration":
-            video_type = main_video_type
-            video["title"] = ""
-
         gloss_video = GlossVideo(
-            title=video["title"],
             gloss=gloss,
             dataset=gloss.dataset,
             videofile=file,
+            title=file,
             version=video["version"],
             is_public=False,
-            video_type=video_type
+            video_type=video_type_map.get(video["video_type"], None)
         )
 
         if not s3_storage_used:

--- a/signbank/dictionary/tests/test_adminviews.py
+++ b/signbank/dictionary/tests/test_adminviews.py
@@ -110,11 +110,10 @@ class GlossListViewTestCase(TestCase):
             "testvid.mp4", b'data \x00\x01', content_type="video/mp4")
         glossvid = GlossVideo.objects.create(
             gloss=testgloss,
-            is_public=True,
+            is_public=False,
             dataset=testgloss.dataset,
             videofile=testfile,
             video_type=validation_video_type,
-            title="Main"
         )
 
         tag_id = Tag.objects.filter(name=settings.TAG_READY_FOR_VALIDATION).values_list("pk", flat=True)[0]

--- a/signbank/dictionary/tests/tests_tasks.py
+++ b/signbank/dictionary/tests/tests_tasks.py
@@ -19,23 +19,34 @@ class RetrieveVideoForGloss(TestCase):
         self.signlanguage = SignLanguage.objects.create(pk=2, name="testsignlanguage",
                                                         language_code_3char="tst")
         self.dataset = Dataset.objects.create(name="testdataset", signlanguage=self.signlanguage)
-        FieldChoice.objects.create(field="video_type", english_name="validation",
-                                   machine_value=random.randint(0, 99999))
+
+        self.main_vt = FieldChoice.objects.create(
+            field="video_type", english_name="main", machine_value=random.randint(0, 99999)
+        )
+        self.finalexample1_vt = FieldChoice.objects.create(
+            field="video_type", english_name="finalexample1",
+            machine_value=random.randint(0, 99999)
+        )
+        self.finalexample2_vt = FieldChoice.objects.create(
+            field="video_type", english_name="finalexample2",
+            machine_value=random.randint(0, 99999)
+        )
         self.gloss = Gloss.objects.create(idgloss="testgloss", dataset=self.dataset)
 
     @override_settings(MEDIA_ROOT="")
     def test_retrieve_videos_for_glosses(self):
-        video_details = [{
-            "url": "/kiwifruit-2-6422.png",
-            "file_name": (
-                f"{settings.MEDIA_ROOT}/glossvideo/"
-                f"{self.gloss.pk}-{self.gloss.idgloss}_illustration_0.png"
-            ),
-            "gloss_pk": self.gloss.pk,
-            "title": "Illustration",
-            "version": 0
-        }]
-        title_before_task_run = video_details[0]["title"]
+        video_details = [
+            {
+                "url": "/kiwifruit_1.mp4",
+                "file_name": (
+                    f"{settings.MEDIA_ROOT}/glossvideo/"
+                    f"{self.gloss.pk}-{self.gloss.idgloss}_finalexample_1.png"
+                ),
+                "gloss_pk": self.gloss.pk,
+                "video_type": "finalexample1",
+                "version": 0
+            }
+        ]
         dummy_file = SimpleUploadedFile(
             video_details[0]["file_name"], b'data \x00\x01', content_type="video/mp4")
 
@@ -51,5 +62,6 @@ class RetrieveVideoForGloss(TestCase):
         self.assertTrue(videos.exists())
         self.assertEqual(videos.count(), 1)
         video = videos.get()
-        self.assertNotEqual(video.title, title_before_task_run)
-        self.assertEqual(video.title, "")
+        self.assertEqual(video.video_type, self.finalexample1_vt)
+        self.assertEqual(video.title, dummy_file.name)
+

--- a/signbank/video/tests/test_views.py
+++ b/signbank/video/tests/test_views.py
@@ -332,5 +332,3 @@ class GlossVideoTokenSignedUrlTestCase(TestCase):
             response.url,
             self.glossvid.videofile.storage.url(self.glossvid.videofile.name)
         )
-        video_tokens = GlossVideoToken.objects.all()
-        self.assertEqual(video_tokens.count(), 0)

--- a/signbank/video/views.py
+++ b/signbank/video/views.py
@@ -35,7 +35,6 @@ def get_signed_video_url_from_glossvideotoken(request, token, videoid):
 
     video = video_token.video
     url = video.videofile.storage.url(video.videofile.name)
-    video_token.delete()
     return redirect(url)
 
 


### PR DESCRIPTION
From Slack discussion:
- videos imported in the NZSL Share CSV import need to set the `video_type` to `main` or `finalexample`, not the title.
- the ready-for-validation export should filter for videos that are of `video_type` `validation`
- the signed_url in the ready-for-validation export needs to be accessible multiple times