### PR TITLE
NZSL-173 Show correct quantities on Qualtrics csv import confirmation

### DIFF
--- a/signbank/dictionary/csv_import.py
+++ b/signbank/dictionary/csv_import.py
@@ -650,6 +650,7 @@ def confirm_import_qualtrics_csv(request):
     validation_records = []
     missing_gloss_pk_question_pairs = {}
     bulk_tagged_items = []
+    gloss_pks = set()
 
     if "validation_records" and "question_numbers" and "question_glossvideo_map" in request.session:
         # Retrieve glosses
@@ -662,7 +663,6 @@ def confirm_import_qualtrics_csv(request):
         questions_numbers = request.session["question_numbers"]
         question_glossvideo_map = request.session["question_glossvideo_map"]
         validation_records = request.session["validation_records"]
-        gloss_pks = []
 
         # Go through csv data
         for record in validation_records:
@@ -687,7 +687,7 @@ def confirm_import_qualtrics_csv(request):
                         respondent_last_name=respondent_last_name,
                         comment=record.get(f"{question_number}_Q2_5_TEXT", ""),
                     ))
-                    gloss_pks.append(gloss.pk)
+                    gloss_pks.add(gloss.pk)
                 except KeyError:
                     missing_gloss_pk_question_pairs[question_number] = question_glossvideo_map[
                         question_number]

--- a/signbank/dictionary/tests/test_csv_import.py
+++ b/signbank/dictionary/tests/test_csv_import.py
@@ -490,6 +490,9 @@ class QualtricsCSVImportTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(response.context["missing_gloss_question_pairs"], {"3": 222})
+        self.assertEqual(response.context["validation_record_count"], 6)
+        self.assertEqual(response.context["responses_count"], 3)
+        self.assertEqual(response.context["gloss_count"], 2)
 
         # check the details of the validation records
         validation_qs_gloss_1 = ValidationRecord.objects.filter(gloss=self.gloss_1)


### PR DESCRIPTION
Issue identified by Micky:
![image (2)](https://github.com/ODNZSL/NZSL-signbank/assets/26726841/424df0a4-bf9e-4f86-b9c0-bcd0d22a4b10)
Incorrect number was displayed on successful validation results import from Qualtrics.

Reason: gloss PKs were appended multiple times, so converted to use `set` rather than a `list`