### PR TITLE
CCSD-4469 NZSL Share to Signbank import allow video re-import

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -4,3 +4,5 @@ ignore:
   - GHSA-jpcq-cgw6-v4j6
   - GHSA-rmxg-73gg-4p98
   - GHSA-257q-pv89-v3xv # GHSA says affected versions are jQuery v.2.2.0 until v.3.5.0
+  - GHSA-vm8q-m57g-pff3
+  - GHSA-w3h3-4rj7-4ph4

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -10,7 +10,6 @@ from django.db import connection
 from .models import FieldChoice, Gloss
 from ..video.models import GlossVideo
 
-
 class VideoDetail(TypedDict):
     url: str
     file_name: str
@@ -62,6 +61,7 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     - title
     - version
     """
+
     main_video_type = FieldChoice.objects.filter(field="video_type", english_name="main").first()
     finalexample_1_video_type = FieldChoice.objects.filter(
         field="video_type",

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -10,6 +10,7 @@ from django.db import connection
 from .models import FieldChoice, Gloss
 from ..video.models import GlossVideo
 
+
 class VideoDetail(TypedDict):
     url: str
     file_name: str
@@ -61,7 +62,6 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     - title
     - version
     """
-
     main_video_type = FieldChoice.objects.filter(field="video_type", english_name="main").first()
     finalexample_1_video_type = FieldChoice.objects.filter(
         field="video_type",

--- a/signbank/dictionary/tests/test_csv_import.py
+++ b/signbank/dictionary/tests/test_csv_import.py
@@ -165,7 +165,7 @@ class ShareCSVImportTestCase(TestCase):
         self.assertListEqual([csv_content[0]], session["glosses_new"])
         self.assertListEqual([csv_content[1]], response.context["skipped_existing_glosses"])
 
-    def test_share_ids_existing_on_glosses_with_no_videos_are_not_skipped(self):
+    def test_share_ids_existing_on_glosses_with_no_videos_have_their_videos_reimported(self):
         """
         Test a csv file row, for which an existing gloss has the share id associated with it,
         is not skipped if it has no video associated (glosses without videos may be re-imported)

--- a/signbank/dictionary/tests/test_csv_import.py
+++ b/signbank/dictionary/tests/test_csv_import.py
@@ -125,10 +125,11 @@ class ShareCSVImportTestCase(TestCase):
         self.assertEqual(self.dataset.pk, session["dataset_id"])
         self.assertListEqual([self._csv_content], session["glosses_new"])
 
-    def test_share_ids_existing_on_glosses_are_skipped(self):
+    def test_share_ids_existing_on_glosses_with_videos_are_skipped(self):
         """
-        Test a csv file which contains a row for which an existing gloss has the share id
-        associated with it is skipped
+        Test a csv file row, for which an existing gloss has the share id associated
+        with it, is skipped, so long as it has a video (glosses with videos may not
+        be re-imported)
         """
         file_name = "test.csv"
         csv_content = [copy.deepcopy(self._csv_content), copy.deepcopy(self._csv_content)]
@@ -143,7 +144,15 @@ class ShareCSVImportTestCase(TestCase):
         file = SimpleUploadedFile(
             content=data.read(), name=data.name, content_type="content/multipart"
         )
-        Gloss.objects.create(dataset=self.dataset, idgloss="Share:11", nzsl_share_id="12345")
+        gloss = Gloss.objects.create(dataset=self.dataset, idgloss="Share:11", nzsl_share_id="12345")
+        GlossVideo.objects.create(
+            gloss=gloss,
+            is_public=True,
+            dataset=Dataset.objects.create(name="testdataset2", signlanguage=self.signlanguage),
+            videofile=SimpleUploadedFile("testvid.mp4", b'data \x00\x01', content_type="video/mp4"),
+            video_type=FieldChoice.objects.first(),
+            title="Main"
+        )
 
         response = self.client.post(
             reverse('dictionary:import_nzsl_share_gloss_csv'),
@@ -155,6 +164,38 @@ class ShareCSVImportTestCase(TestCase):
         self.assertEqual(self.dataset.pk, session["dataset_id"])
         self.assertListEqual([csv_content[0]], session["glosses_new"])
         self.assertListEqual([csv_content[1]], response.context["skipped_existing_glosses"])
+
+    def test_share_ids_existing_on_glosses_with_no_videos_are_not_skipped(self):
+        """
+        Test a csv file row, for which an existing gloss has the share id associated with it,
+        is not skipped if it has no video associated (glosses without videos may be re-imported)
+        """
+        file_name = "test.csv"
+        csv_content = [copy.deepcopy(self._csv_content), copy.deepcopy(self._csv_content)]
+        csv_content[1]["id"] = "12345"
+
+        with open(file_name, "w") as file:
+            writer = csv.writer(file)
+            writer.writerow(csv_content[0].keys())
+            for row in csv_content:
+                writer.writerow(row.values())
+        data = open(file_name, "rb")
+        file = SimpleUploadedFile(
+            content=data.read(), name=data.name, content_type="content/multipart"
+        )
+        gloss = Gloss.objects.create(dataset=self.dataset, idgloss="Share:11", nzsl_share_id="12345")
+        response = self.client.post(
+            reverse('dictionary:import_nzsl_share_gloss_csv'),
+            {"dataset": self.dataset.pk, "file": file},
+            format="multipart"
+        )
+        self.assertEqual(response.status_code, 200)
+        session = self.client.session
+        self.assertEqual(self.dataset.pk, session["dataset_id"])
+        with self.assertRaises(AssertionError):
+            self.assertListEqual([csv_content[0]], session["glosses_new"])
+        with self.assertRaises(AssertionError):
+            self.assertListEqual([csv_content[1]], response.context["skipped_existing_glosses"])
 
     def test_confirmation_view_confirm_gloss_creation(self):
         """


### PR DESCRIPTION
## JIRA Ticket

[[CCSD-4469] NZSL: NZSL Share to Signbank import has not carried over the videos](https://ackama.atlassian.net/browse/CCSD-4469)

## Changes
- Allows glosses with pre-existing `nzsl_share_id` to be re-imported, if they do not have associated videos: catches case where sometimes NZSL Share imports lose the videos due to network/S3 issues etc.
- Only imports the video component for existing glosses, not any of their other components.
- Positive and negative unit test cases added.
- Unit test catches graceful handling where manual intervention has resulted in garbled nzsl_share_id values, eg. duplicates.
- Fixed some existing messaging spelling errors.


## Video
(Apologies for jerkiness, did not realise it was capturing both screens.)
1. CSV of a handful of new glosses is imported.
2. The GlossVideo records of the gloss "Minecraft" are removed.
3. The same CSV is re-imported.
4. You can see that only "Minecraft" is re-imported.

The videos do get imported correctly but to demonstrate that requires other administrative setup that is out of scope here.

https://github.com/ODNZSL/NZSL-signbank/assets/82071930/2608a9d1-7351-4fd9-a9fe-4b6f630fb782




