### PR TITLE
CC-2137 followup - NZSL: move signbank to Poetry

### DIFF
--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -8,7 +8,7 @@ import pathlib
 import sys
 
 import dj_database_url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 sentry_dsn = os.environ.get('SENTRY_DSN', '')


### PR DESCRIPTION
Fix reversion that was preventing important functions working, eg. new gloss.

## JIRA Ticket
[CC-2137 NZSL: move signbank to Poetry](https://ackama.atlassian.net/browse/CC-2137)

## Changes
- `ugetttext` is back to being `gettext`

## Notes
This was changed at some point in `django/utils/translation`, with effect the interim measure (required at one point during phased upgrades) of aliasing the two calls together stopped working