### PR TITLE
NZSL: Change docker-compose to docker compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: cp example.env .env
-    - name: Build the docker-compose stack
-      run: docker-compose up -d
+    - name: Build the docker compose stack
+      run: docker compose up -d
     - name: Check running containers
       run: docker ps -a
     - name: Check logs
-      run: docker-compose logs backend
+      run: docker compose logs backend
     - name: Run test suite
-      run: docker-compose run backend bin/runtests.py
+      run: docker compose run backend bin/runtests.py
     - name: Deploy app to UAT
       if: github.ref == 'refs/heads/master'
       env:
@@ -33,7 +33,7 @@ jobs:
         HEROKU_APP_NAME: ${{secrets.HEROKU_UAT_APP_NAME}}
       run: |
         echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
-        docker tag $(docker-compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
+        docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
         docker push registry.heroku.com/$HEROKU_APP_NAME/web
         heroku container:release web -a $HEROKU_APP_NAME
     - name: Deploy app to Production
@@ -43,6 +43,6 @@ jobs:
         HEROKU_APP_NAME: ${{secrets.HEROKU_PRODUCTION_APP_NAME}}
       run: |
         echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
-        docker tag $(docker-compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
+        docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
         docker push registry.heroku.com/$HEROKU_APP_NAME/web
         heroku container:release web -a $HEROKU_APP_NAME


### PR DESCRIPTION
Changing `docker-compose` to `docker compose`, as the former is no longer supported anywhere including Travis.
Leaving OSV warnings as they will be addressed by other PRs soon enough.
