### PR TITLE
OSV ignore GHSA-248v-346w-9cwc GHSA-g92j-qhmh-64v2 GHSA-9mvj-f7w8-pvh2

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -6,3 +6,7 @@ ignore:
   - GHSA-257q-pv89-v3xv # GHSA says affected versions are jQuery v.2.2.0 until v.3.5.0
   - GHSA-vm8q-m57g-pff3
   - GHSA-w3h3-4rj7-4ph4
+  - GHSA-248v-346w-9cwc # Certifi removes GLOBALTRUST root certificate (https://github.com/advisories/GHSA-248v-346w-9cwc)
+  - GHSA-g92j-qhmh-64v2 # Sentry's Python SDK unintentionally exposes environment variables to subprocesses (https://github.com/advisories/GHSA-g92j-qhmh-64v2)
+  - GHSA-9mvj-f7w8-pvh2 # Bootstrap Cross-Site Scripting (XSS) vulnerability (https://github.com/advisories/GHSA-9mvj-f7w8-pvh2)
+


### PR DESCRIPTION
OSV ignores until we are able to apply patches (Blocked by other work).
 - GHSA-248v-346w-9cwc # Certifi removes GLOBALTRUST root certificate (https://github.com/advisories/GHSA-248v-346w-9cwc)
 - GHSA-g92j-qhmh-64v2 # Sentry's Python SDK unintentionally exposes environment variables to subprocesses (https://github.com/advisories/GHSA-g92j-qhmh-64v2)
 - GHSA-9mvj-f7w8-pvh2 # Bootstrap Cross-Site Scripting (XSS) vulnerability (https://github.com/advisories/GHSA-9mvj-f7w8-pvh2)
