### PR TITLE
ci: use environments when deploying

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Check dependencies for security vulnerabilities
         uses: g-rath/check-with-osv-detector@main
-  build:
+  tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -26,8 +26,27 @@ jobs:
       run: docker compose logs backend
     - name: Run test suite
       run: docker compose run backend bin/runtests.py
+
+  deploy_to_uat:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs:
+      - check-dependencies
+      - tests
+    environment:
+      name: uat
+      url: https://signbank-uat.nzsl.nz
+    steps:
+    - uses: actions/checkout@v1
+    - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+    - run: cp example.env .env
+    - name: Build the docker compose stack
+      run: docker compose up -d
+    - name: Check running containers
+      run: docker ps -a
+    - name: Check logs
+      run: docker compose logs backend
     - name: Deploy app to UAT
-      if: github.ref == 'refs/heads/master'
       env:
         HEROKU_API_KEY: ${{secrets.HEROKU_UAT_API_KEY}}
         HEROKU_APP_NAME: ${{secrets.HEROKU_UAT_APP_NAME}}
@@ -36,6 +55,25 @@ jobs:
         docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
         docker push registry.heroku.com/$HEROKU_APP_NAME/web
         heroku container:release web -a $HEROKU_APP_NAME
+  deploy_to_production:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    needs:
+      - check-dependencies
+      - tests
+    environment:
+      name: production
+      url: https://signbank.nzsl.nz
+    steps:
+    - uses: actions/checkout@v1
+    - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+    - run: cp example.env .env
+    - name: Build the docker compose stack
+      run: docker compose up -d
+    - name: Check running containers
+      run: docker ps -a
+    - name: Check logs
+      run: docker compose logs backend
     - name: Deploy app to Production
       if: github.ref == 'refs/heads/production'
       env:


### PR DESCRIPTION
This means that GitHub will be able to track deployments, and in turn we should start getting these properly logged in Mahi.

As part of this, I've introduced a new `tests` job that handles running the test suite, and made it a requirement that both that job and the auditing job pass before a deployment will happen; I will handle formatting and security hardening in a follow up PR