### PR TITLE
CCSD-5147: Replace is_ajax() call with http META test

### DIFF
--- a/signbank/video/views.py
+++ b/signbank/video/views.py
@@ -422,7 +422,7 @@ def change_glossvideo_publicity(request):
 
         video.set_public(is_public)
 
-        if request.is_ajax():
+        if request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest':
             return HttpResponse(status=200)
 
     referer = request.META.get("HTTP_REFERER")


### PR DESCRIPTION

This is fallout from the Django 4.2 upgrade #170 
The symptom was that in Advanced Edit the 'Set private/Set public' button would not show any change until the page was refreshed.  This was due to a Server 500 in the backend, where it was trying to call the no-longer supported function `is_ajax()`. This had to be replaced with the new accepted way of doing things.

## JIRA Ticket

[CCSD-5147 NZSL-Signbank: UAT, public private button requires refresh](https://ackama.atlassian.net/browse/CCSD-5147)

## Changes
- `signbank/video/views.py` had the deprecated(now removed) `is_ajax()` call. Replaced it with a test for `HTTP_X_REQUESTED_WITH` which is the same fix we have applied elsewhere.
