### PR TITLE
CCSD-5158: Add headers to prevent 403s on Video import from NZSL share

### DIFF
--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -2,7 +2,7 @@ import boto3
 import os
 from tempfile import TemporaryDirectory
 from typing import TypedDict, List
-from urllib.request import urlretrieve
+from urllib.request import urlretrieve, build_opener, install_opener
 
 from django.conf import settings
 from django.db import connection
@@ -82,6 +82,11 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
 
     s3 = boto3.client("s3")
     s3_storage_used = settings.GLOSS_VIDEO_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage"
+
+    # Set headers for urlretrieve()
+    opener = build_opener()
+    opener.addheaders = settings.NZSL_SHARE_HEADERS
+    install_opener(opener)
 
     for video in video_details:
         retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -85,7 +85,7 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
 
     # Set headers for urlretrieve()
     opener = build_opener()
-    opener.addheaders = settings.NZSL_SHARE_HEADERS
+    opener.addheaders = [('Accept', '*/*')]
     install_opener(opener)
 
     for video in video_details:

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -261,6 +261,7 @@ else:
 
 NZSL_SHARE_HOSTNAME = os.getenv('NZSL_SHARE_HOSTNAME')
 
+
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)
 

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -261,9 +261,6 @@ else:
 
 NZSL_SHARE_HOSTNAME = os.getenv('NZSL_SHARE_HOSTNAME')
 
-# Prevents 403 Forbidden when retrieving videos via Share --redirect--> S3
-NZSL_SHARE_HEADERS = [('Accept', '*/*'), ('User-agent', 'curl/7.74.0')]
-
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)
 

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -261,6 +261,8 @@ else:
 
 NZSL_SHARE_HOSTNAME = os.getenv('NZSL_SHARE_HOSTNAME')
 
+# Prevents 403 Forbidden when retrieving videos via Share --redirect--> S3
+NZSL_SHARE_HEADERS = [('Accept', '*/*'), ('User-agent', 'curl/7.74.0')]
 
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)


### PR DESCRIPTION
## JIRA Ticket

[CCSD-5158 NZSL Signbank UAT: Video import from NZSL share fails](https://ackama.atlassian.net/browse/CCSD-5158)

## Notes

This PR could be a fix for the issue at hand, but its first purpose is to formalise what has been discovered that works so far.

---

NZSL Signbank imports glosses and their videos from NZSL Share, via a CSV file of field values and urls exported by NZSL Share.
The import of video files is performed via a background thread launched from the import page in Signbank.

This background thread calls the function `urllib.request.urlretrieve()` to do the actual video fetch from S3.
The relevant code area is: `retrieve_videos_for_glosses()`
https://github.com/ODNZSL/NZSL-signbank/blob/master/signbank/dictionary/tasks.py#L54


Post the upgrade to Django 4.2, it was noticed by the client that on Signbank UAT, videos were not importing from Share UAT.

Due to the config variable `NZSL_SHARE_HOST`, a Signbank instance must choose its NZSL Share import source - ie. Share UAT or Share Production. Therefore Signbank UAT is set to import from Share UAT.


Signbank UAT was found to have the _incorrect_ value for `NZSL_SHARE_HOST`, so video imports would have failed anyway. However, this turned out to be a red-herring, and not the important issue.

It does, however, suggest that UAT Signbank hasn't been checked thoroughly for some time, and therefore possibly the rest of the issue was nothing to do with the Django upgrade. That is still to be determined. However rolling back the codebase to before the upgrade seemed to result in the same outcomes.


After correcting the `NZSL_SHARE_HOST` value, the mystery deepened. It was found that the videos were sometimes importing, sometimes not, and the problem seemed to be random.


Various things were eliminated:

- The temporary urls produced in the Export process by NZSL Share were correct and not the problem
- For any given url, the redirect performed by NZSL Share was going to the correct S3 target
- The S3 target could be accessed via a web browser
- `curl` could negotiate the redirect and retrieve the file correctly
- `curl` could access the S3 target directly and retrieve the file correctly


Upon investigation, some significant points were revealed:

- Running `urlretrieve()` manually, on a known good url (be it a Share url or the subsequent s3 redirect used directly), would fail approximately 50% of the attempts, with a `403 Forbidden` error instead of a `200 Success`, and scripted testing confirmed this

- `curl` never failed, run from inside the same docker instance that was performing the `urlretrieve()` above

- The headers reaching the target were slightly different between `curl` and `urlretrieve()` (that is, `python urllib`), verified using the site [Webhook](https://webhook.site)


It was then discovered that if the headers were set to contain either or both of:
- `Accept: */*`
- `User-agent: <any browser user agent, or curl's>`

Then `urlretrieve()` would successfully retrieve the target file on 100% of the attempts.


This appears to be, at writing, either an S3 issue or a Cloudflare issue, but there may be other possibilities.


## Changes

- `NZSL_SHARE_HEADERS` array added to `settings`, contains `Accept` and `User-agent` HTTP headers
- `urllib` use in `retrieve_videos_for_glosses()` expanded to `build_opener()` and `install_opener()`, which enables use of the headers in `NZSL_SHARE_HEADERS`




