### PR TITLE
CCSD-5141: Sort multicheckbox alphabetically by label

### DIFF
--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -137,7 +137,12 @@ $.editable.addInputType('multicheckbox', {
             return submitdata;
         };
 
-        $.each(settings.data || [], function(value, label) {
+        // Output multicheckbox in label alphabetical order
+        const data_inverted = Object.fromEntries(Object.entries(settings.data).map(([k, v]) => [v, k]));
+        var dkeys = Object.keys(data_inverted);
+        dkeys.sort();
+        dkeys.forEach(function(label) {
+            var value = data_inverted[label];
             if (value === "selected") {
                 return;
             }

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -137,16 +137,13 @@ $.editable.addInputType('multicheckbox', {
             return submitdata;
         };
 
-        // Output multicheckbox in label alphabetical order
+        // Output multicheckbox in alphabetical order of labels
         const data_inverted = Object.fromEntries(Object.entries(settings.data).map(([k, v]) => [v, k]));
-        var dkeys = Object.keys(data_inverted);
-        dkeys.sort();
-        dkeys.forEach(function(label) {
+        Object.keys(data_inverted).sort().forEach(function(label) {
             var value = data_inverted[label];
             if (value === "selected") {
                 return;
             }
-
             $el.append($("<label><input type='checkbox' value='" + value + "' /></label><br />"));
         });
 

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -137,13 +137,11 @@ $.editable.addInputType('multicheckbox', {
             return submitdata;
         };
 
-        // Output multicheckbox in alphabetical order of labels
-        const data_inverted = Object.fromEntries(Object.entries(settings.data).map(([k, v]) => [v, k]));
-        Object.keys(data_inverted).sort().forEach(function(label) {
-            var value = data_inverted[label];
+        $.each(settings.data || [], function(value, label) {
             if (value === "selected") {
                 return;
             }
+
             $el.append($("<label><input type='checkbox' value='" + value + "' /></label><br />"));
         });
 

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -138,14 +138,14 @@ $.editable.addInputType('multicheckbox', {
         };
 
         // Output multicheckbox in alphabetical order of labels
-        const data_inverted = Object.fromEntries(Object.entries(settings.data).map(([k, v]) => [v, k]));
-        Object.keys(data_inverted).sort().forEach(function(label) {
-            var value = data_inverted[label];
-            if (value === "selected") {
-                return;
-            }
-            $el.append($("<label><input type='checkbox' value='" + value + "' /></label><br />"));
-        });
+        Object.entries(settings.data)
+            .sort(([, a], [, b]) => a.localeCompare?.(b))
+            .forEach(([value, label]) => {
+                if (value === "selected") {
+                    return;
+                }
+                $el.append($("<label><input type='checkbox' value='" + value + "' /></label><br />"));
+            });
 
         return $el.find("input[type='checkbox']");
     },

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -138,7 +138,7 @@ $.editable.addInputType('multicheckbox', {
         };
 
         // Output multicheckbox in alphabetical order of labels
-        Object.entries(settings.data)
+        Object.entries(settings.data ?? [])
             .sort(([, a], [, b]) => a.localeCompare?.(b))
             .forEach(([value, label]) => {
                 if (value === "selected") {

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -137,11 +137,13 @@ $.editable.addInputType('multicheckbox', {
             return submitdata;
         };
 
-        $.each(settings.data || [], function(value, label) {
+        // Output multicheckbox in alphabetical order of labels
+        const data_inverted = Object.fromEntries(Object.entries(settings.data).map(([k, v]) => [v, k]));
+        Object.keys(data_inverted).sort().forEach(function(label) {
+            var value = data_inverted[label];
             if (value === "selected") {
                 return;
             }
-
             $el.append($("<label><input type='checkbox' value='" + value + "' /></label><br />"));
         });
 


### PR DESCRIPTION
## JIRA Ticket

[CCSD-5141 NZSL Signbank: put semantic field list in alphabetical order](https://ackama.atlassian.net/browse/CCSD-5141)

## Changes

- Pre-sort by label added to `multicheckbox` pre-processor in `gloss_edit.py`

## Notes

This makes _all_ `multicheckbox` fields (semantic field, word category, and usage) sorted by alphabetical order.
Micky Vale has confirmed that this is Ok and a desirable feature.
