### PR TITLE
CC-2499: update `docker-compose` to use postgres version now in production 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
           database:
             condition: service_healthy
     database:
-        image: postgres:14
+        image: postgres:17
         environment:
           - "POSTGRES_PASSWORD=postgres"
         ports:


### PR DESCRIPTION
We've upgrade to postgres v17 in production, this PR updates the `docker-compose` file so we're using the same version in local development. 