### PR TITLE
chore: update ignores

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,2 +1,3 @@
 ignore:
   - GHSA-9mvj-f7w8-pvh2
+  - GHSA-pq67-6m6q-mj2v


### PR DESCRIPTION
We are currently blocked on patching `urllib3` until we upgrade python. 