### PR TITLE
chore: ignore bootstrap vuln to unblock ci

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,2 +1,3 @@
 ignore:
   - GHSA-9mvj-f7w8-pvh2
+  - GHSA-q58r-hwc8-rm9j


### PR DESCRIPTION
The most recent production deployment failed due a dependency check- but this is currently unpatched so to unblock CI I've added it to the ignores list: [GHSA-q58r-hwc8-rm9j](https://github.com/advisories/GHSA-q58r-hwc8-rm9j)