### PR TITLE
chore: update js ignores

### DIFF
--- a/.osv-detector.yml
+++ b/.osv-detector.yml
@@ -1,3 +1,3 @@
 ignore:
-  - GHSA-9mvj-f7w8-pvh2
   - GHSA-q58r-hwc8-rm9j
+  - GHSA-vxmc-5x29-h64v


### PR DESCRIPTION
* GHSA-9mvj-f7w8-pvh2 has been withdrawn
* GHSA-vxmc-5x29-h64v is not exploitable and requires a major upgrade of bootstrap to address, which won't happen anytime soon