### PR TITLE
CCSD-5559: Improve NZSL Share -> Signbank video import batches

### DIFF
--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -10,6 +10,9 @@ from django.db import connection
 from .models import FieldChoice, Gloss
 from ..video.models import GlossVideo
 
+# Bite size to split video_details up into
+VIDEO_BATCH_LENGTH = 10
+
 
 class VideoDetail(TypedDict):
     url: str
@@ -76,7 +79,6 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
         "finalexample1": finalexample_1_video_type,
         "finalexample2": finalexample_2_video_type
     }
-    videos_to_create = []
 
     temp_dir = TemporaryDirectory(dir=settings.MEDIA_ROOT)
 
@@ -88,41 +90,53 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
     opener.addheaders = [('Accept', '*/*')]
     install_opener(opener)
 
-    for video in video_details:
-        retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"
+    # Batch up the list in case it is long
+    video_batches = [
+        video_details[i: i + VIDEO_BATCH_LENGTH]
+        for i in range(0, len(video_details), VIDEO_BATCH_LENGTH)
+    ]
+    for video_batch in video_batches:
+        videos_to_create = []
+        for video in video_batch:
+            retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"
 
-        if s3_storage_used:
-            file, _ = urlretrieve(
-                retrieval_url,
-                video["file_name"]
+            print(video["file_name"])
+            if s3_storage_used:
+                try:
+                    file, _ = urlretrieve(
+                        retrieval_url,
+                        video["file_name"]
+                    )
+                except FileNotFoundError as e:
+                    print(e)
+                    continue
+                s3.upload_file(
+                    file, settings.AWS_STORAGE_BUCKET_NAME, video["file_name"]
+                )
+            else:
+                file_name = f"{temp_dir.name}/{video['file_name']}"
+                file, _ = urlretrieve(
+                    retrieval_url,
+                    file_name
+                )
+
+            gloss = Gloss.objects.get(pk=video["gloss_pk"])
+
+            gloss_video = GlossVideo(
+                gloss=gloss,
+                dataset=gloss.dataset,
+                videofile=file,
+                title=file,
+                version=video["version"],
+                is_public=False,
+                video_type=video_type_map.get(video["video_type"], None)
             )
-            s3.upload_file(
-                file, settings.AWS_STORAGE_BUCKET_NAME, video["file_name"]
-            )
-        else:
-            file_name = f"{temp_dir.name}/{video['file_name']}"
-            file, _ = urlretrieve(
-                retrieval_url,
-                file_name
-            )
 
-        gloss = Gloss.objects.get(pk=video["gloss_pk"])
+            if not s3_storage_used:
+                gloss_video = move_glossvideo_to_valid_filepath(gloss_video)
+            videos_to_create.append(gloss_video)
 
-        gloss_video = GlossVideo(
-            gloss=gloss,
-            dataset=gloss.dataset,
-            videofile=file,
-            title=file,
-            version=video["version"],
-            is_public=False,
-            video_type=video_type_map.get(video["video_type"], None)
-        )
-
-        if not s3_storage_used:
-            gloss_video = move_glossvideo_to_valid_filepath(gloss_video)
-        videos_to_create.append(gloss_video)
-
-    GlossVideo.objects.bulk_create(videos_to_create)
+        GlossVideo.objects.bulk_create(videos_to_create, ignore_conflicts=True)
 
     temp_dir.cleanup()
     connection.close()

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -88,8 +88,8 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
 
     # Batch up the list in case it is long
     video_batches = [
-        video_details[i: i + settings.NZSL_SHARE_BATCH_LENGTH]
-        for i in range(0, len(video_details), settings.NZSL_SHARE_BATCH_LENGTH)
+        video_details[i: i + settings.NZSL_SHARE_BATCH_SIZE]
+        for i in range(0, len(video_details), settings.NZSL_SHARE_BATCH_SIZE)
     ]
     for video_batch in video_batches:
         videos_to_create = []

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -1,5 +1,4 @@
 import boto3
-import os
 from tempfile import TemporaryDirectory
 from typing import TypedDict, List
 from urllib.request import urlretrieve, build_opener, install_opener
@@ -99,8 +98,6 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
         videos_to_create = []
         for video in video_batch:
             retrieval_url = f"{settings.NZSL_SHARE_HOSTNAME}{video['url']}"
-
-            print(video["file_name"])
             if s3_storage_used:
                 try:
                     file, _ = urlretrieve(

--- a/signbank/dictionary/tasks.py
+++ b/signbank/dictionary/tasks.py
@@ -9,9 +9,6 @@ from django.db import connection
 from .models import FieldChoice, Gloss
 from ..video.models import GlossVideo
 
-# Bite size to split video_details up into
-VIDEO_BATCH_LENGTH = 10
-
 
 class VideoDetail(TypedDict):
     url: str
@@ -91,8 +88,8 @@ def retrieve_videos_for_glosses(video_details: List[VideoDetail]):
 
     # Batch up the list in case it is long
     video_batches = [
-        video_details[i: i + VIDEO_BATCH_LENGTH]
-        for i in range(0, len(video_details), VIDEO_BATCH_LENGTH)
+        video_details[i: i + settings.NZSL_SHARE_BATCH_LENGTH]
+        for i in range(0, len(video_details), settings.NZSL_SHARE_BATCH_LENGTH)
     ]
     for video_batch in video_batches:
         videos_to_create = []

--- a/signbank/dictionary/tests/test_update.py
+++ b/signbank/dictionary/tests/test_update.py
@@ -126,9 +126,9 @@ class UpdateGlossTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         glossvid.refresh_from_db()
         self.assertEqual(glossvid.title, new_title)
-        if os.path.isfile(glossvid.videofile.path):
+        if os.path.isfile(glossvid.videofile.name):
             # Remove the file.
-            os.remove(glossvid.videofile.path)
+            os.remove(glossvid.videofile.name)
 
         # Test updating title for nonexisting glossvideo.
         response = self.client.post(reverse('dictionary:update_gloss', args=[self.testgloss.pk]),

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -255,7 +255,7 @@ else:
     GLOSS_VIDEO_FILE_STORAGE = 'signbank.video.models.GlossVideoStorage'
 
 NZSL_SHARE_HOSTNAME = os.getenv('NZSL_SHARE_HOSTNAME')
-NZSL_SHARE_BATCH_LENGTH = 10
+NZSL_SHARE_BATCH_SIZE = 10
 
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -255,7 +255,7 @@ else:
     GLOSS_VIDEO_FILE_STORAGE = 'signbank.video.models.GlossVideoStorage'
 
 NZSL_SHARE_HOSTNAME = os.getenv('NZSL_SHARE_HOSTNAME')
-
+NZSL_SHARE_BATCH_LENGTH = 10
 
 mimetypes.add_type("video/mp4", ".mov", True)
 mimetypes.add_type("video/webm", ".webm", True)


### PR DESCRIPTION
## JIRA Ticket

[CCSD-5559 NZSL: Share to Signbank import has not brought videos](https://ackama.atlassian.net/browse/CCSD-5559)

## Changes

- Video postgres and S3 import now works in small batches, with postgres write at end of each batch. This makes it much more re-entrant when importing large or very large batches.
- File retrieval can now tolerate errors due to paths and naming.
- Postgres row writes can now tolerate duplicate key errors.
- Unit test with outdated code repaired.
- `black` run.


