### PR TITLE
CCSD-5624: Handle multiple values in query params rather than assuming a single value

### DIFF
--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -250,9 +250,9 @@ function clearForm(myFormElement) {
     <thead>
         <tr>
             <th>{% blocktrans %}Dataset{% endblocktrans %}</th>
-            <th>{% blocktrans %}Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss' or request.GET.order == 'idgloss' %}&order=-idgloss{% else %}&order=idgloss{% endif %}">
+            <th>{% blocktrans %}Gloss{% endblocktrans %} <a href="?search={{request.GET.search|urlencode}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss' or request.GET.order == 'idgloss' %}&order=-idgloss{% else %}&order=idgloss{% endif %}">
                 <span class="{% if request.GET.order|slice:":1" == "-" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
-            <th>{% blocktrans %}Gloss in Māori{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss_mi' or request.GET.order == 'idgloss_mi' %}&order=-idgloss_mi{% else %}&order=idgloss_mi{% endif %}">
+            <th>{% blocktrans %}Gloss in Māori{% endblocktrans %} <a href="?search={{request.GET.search|urlencode}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss_mi' or request.GET.order == 'idgloss_mi' %}&order=-idgloss_mi{% else %}&order=idgloss_mi{% endif %}">
                 <span class="{% if request.GET.order|slice:":1" == "-" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
             <th>{% blocktrans %}Translation equivalents{% endblocktrans %}</th>
             <th>{% blocktrans %}Notes{% endblocktrans %}</th>

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -250,9 +250,9 @@ function clearForm(myFormElement) {
     <thead>
         <tr>
             <th>{% blocktrans %}Dataset{% endblocktrans %}</th>
-            <th>{% blocktrans %}Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,value in request.GET.items %}{% if not key  == 'search' and not key == 'order' %}&{{ key }}={{ value }}{% endif %}{% endfor %}{% if order == 'idgloss' or request.GET.order == 'idgloss' %}&order=-idgloss{% else %}&order=idgloss{% endif %}">
+            <th>{% blocktrans %}Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss' or request.GET.order == 'idgloss' %}&order=-idgloss{% else %}&order=idgloss{% endif %}">
                 <span class="{% if request.GET.order|slice:":1" == "-" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
-            <th>{% blocktrans %}Gloss in Māori{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,value in request.GET.items %}{% if not key  == 'search' and not key == 'order' %}&{{ key }}={{ value }}{% endif %}{% endfor %}{% if order == 'idgloss_mi' or request.GET.order == 'idgloss_mi' %}&order=-idgloss_mi{% else %}&order=idgloss_mi{% endif %}">
+            <th>{% blocktrans %}Gloss in Māori{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'idgloss_mi' or request.GET.order == 'idgloss_mi' %}&order=-idgloss_mi{% else %}&order=idgloss_mi{% endif %}">
                 <span class="{% if request.GET.order|slice:":1" == "-" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
             <th>{% blocktrans %}Translation equivalents{% endblocktrans %}</th>
             <th>{% blocktrans %}Notes{% endblocktrans %}</th>

--- a/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
@@ -131,9 +131,9 @@ function clearForm(myFormElement) {
 <table class='table table-condensed'>
     <thead>
         <tr>
-            <th>{% blocktrans %}Source Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'source' or request.GET.order == 'source' %}&order=-source{% else %}&order=source{% endif %}">
+            <th>{% blocktrans %}Source Gloss{% endblocktrans %} <a href="?search={{request.GET.search|urlencode}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'source' or request.GET.order == 'source' %}&order=-source{% else %}&order=source{% endif %}">
                 <span class="{% if request.GET.order == "-source" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
-            <th>{% blocktrans %}Target Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'target' or request.GET.order == 'target' %}&order=-target{% else %}&order=target{% endif %}">
+            <th>{% blocktrans %}Target Gloss{% endblocktrans %} <a href="?search={{request.GET.search|urlencode}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'target' or request.GET.order == 'target' %}&order=-target{% else %}&order=target{% endif %}">
                 <span class="{% if request.GET.order == "-target" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
             <th>{% blocktrans %}Relation type{% endblocktrans %}</th>
         </tr>

--- a/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_glossrelation_list.html
@@ -131,9 +131,9 @@ function clearForm(myFormElement) {
 <table class='table table-condensed'>
     <thead>
         <tr>
-            <th>{% blocktrans %}Source Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,value in request.GET.items %}{% if not key  == 'search' and not key == 'order' %}&{{ key }}={{ value }}{% endif %}{% endfor %}{% if order == 'source' or request.GET.order == 'source' %}&order=-source{% else %}&order=source{% endif %}">
+            <th>{% blocktrans %}Source Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'source' or request.GET.order == 'source' %}&order=-source{% else %}&order=source{% endif %}">
                 <span class="{% if request.GET.order == "-source" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
-            <th>{% blocktrans %}Target Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,value in request.GET.items %}{% if not key  == 'search' and not key == 'order' %}&{{ key }}={{ value }}{% endif %}{% endfor %}{% if order == 'target' or request.GET.order == 'target' %}&order=-target{% else %}&order=target{% endif %}">
+            <th>{% blocktrans %}Target Gloss{% endblocktrans %} <a href="?search={{request.GET.search}}{% for key,values in request.GET.lists %}{% if not key  == 'search' and not key == 'order' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}{% if order == 'target' or request.GET.order == 'target' %}&order=-target{% else %}&order=target{% endif %}">
                 <span class="{% if request.GET.order == "-target" %}glyphicon glyphicon-sort-by-alphabet{% else %}glyphicon glyphicon-sort-by-alphabet-alt{% endif %}" aria-hidden="true"></span></a></th>
             <th>{% blocktrans %}Relation type{% endblocktrans %}</th>
         </tr>

--- a/signbank/dictionary/templates/dictionary/paginate.html
+++ b/signbank/dictionary/templates/dictionary/paginate.html
@@ -1,7 +1,7 @@
 {% if page_obj.paginator.num_pages > 1 %}
 <ul class="pagination pagination-sm">
     {% if page_obj.has_previous %}
-        <li><a href="?page={{ page_obj.previous_page_number }}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&laquo;</a></li>
+        <li><a href="?page={{ page_obj.previous_page_number }}{% for key,values in request.GET.lists %}{% if key != 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">&laquo;</a></li>
     {% endif %}
     {% if page_obj.number > 10 %}
     <li><a>...</a></li>
@@ -10,7 +10,7 @@
     {% for p in page_obj.paginator.page_range %}
         {% if p < page_obj.number|add:"10" and  p > page_obj.number|add:"-10" %}
         <li {% if p == page_obj.number %}class='active'{% endif %}>
-        <a href="?page={{ p }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">{% if p == 0 %}Start{% else %}{{p}}{% endif %}</a>
+        <a href="?page={{ p }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">{% if p == 0 %}Start{% else %}{{p}}{% endif %}</a>
         </li>
         {% endif %}
     {% endfor %}
@@ -18,12 +18,12 @@
     {% if page_obj.paginator.num_pages > page_obj.number|add:"10" %}
     <li><a>...</a></li>
     <li>
-        <a href="?page={{ page_obj.paginator.num_pages }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">{{page_obj.paginator.num_pages}}</a>
+        <a href="?page={{ page_obj.paginator.num_pages }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">{{page_obj.paginator.num_pages}}</a>
     </li>
     {% endif %}
 
     {% if page_obj.has_next %}
-        <li><a href="?page={{ page_obj.next_page_number }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&raquo;</a></li>
+        <li><a href="?page={{ page_obj.next_page_number }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">&raquo;</a></li>
     {% endif %}
 </ul>
 {% endif %}

--- a/templates/comments/search_comments.html
+++ b/templates/comments/search_comments.html
@@ -46,13 +46,13 @@
     <span class="step-links">
         <ul class="pagination pagination-sm">
         {% if page_obj.has_previous %}{# Insert dataset from request #}
-            <li><a href="?page={{ page_obj.previous_page_number }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&laquo; {% blocktrans %}previous{% endblocktrans %}</a>
+            <li><a href="?page={{ page_obj.previous_page_number }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">&laquo; {% blocktrans %}previous{% endblocktrans %}</a>
         {% endif %}
         {% for curpage in page_obj.paginator.page_range %}
-            <li{% if curpage == page_obj.number %} class="active"{% endif %}><a href="?page={{ curpage }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">{{ curpage }}</a>
+            <li{% if curpage == page_obj.number %} class="active"{% endif %}><a href="?page={{ curpage }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">{{ curpage }}</a>
         {% endfor %}
         {% if page_obj.has_next %}
-            <li><a href="?page={{ page_obj.next_page_number }}{% for key,value in request.GET.items %}{% if not key == 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">{% blocktrans %}next{% endblocktrans %} &raquo;</a>
+            <li><a href="?page={{ page_obj.next_page_number }}{% for key,values in request.GET.lists %}{% if not key == 'page' %}{% for value in values %}&{{ key }}={{ value|urlencode }}{% endfor %}{% endif %}{% endfor %}">{% blocktrans %}next{% endblocktrans %} &raquo;</a>
         {% endif %}
         </ul>
         <p>{% blocktrans %}Total of{% endblocktrans %} {{ page_obj.paginator.count }} {% blocktrans context 'count' %}comments{% endblocktrans %}.</p>


### PR DESCRIPTION
This pull request fixes an issue where multiple selection inputs were not correctly serialized into pagination links. This is because `request.GET.items` always returns the first value in multiple-value items rather than multiple values. Instead, we use `request.GET.lists`, which returns lists (single values have a single list item). This correctly serializes multiple choice inputs.

This resolves the issue observed by Micky on the gloss search pages, as well as one additional page that is affected by this (the sign comments list)