### PR TITLE
ci: have Heroku cli handle building and pushing containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
         docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
-        docker push registry.heroku.com/$HEROKU_APP_NAME/web
+        heroku container:login
         heroku container:release web -a $HEROKU_APP_NAME
   deploy_to_production:
     runs-on: ubuntu-latest
@@ -74,5 +74,5 @@ jobs:
       run: |
         echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
         docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
-        docker push registry.heroku.com/$HEROKU_APP_NAME/web
+        heroku container:login
         heroku container:release web -a $HEROKU_APP_NAME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,16 +40,13 @@ jobs:
     - uses: actions/checkout@v1
     - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
     - run: cp example.env .env
-    - name: Build the docker compose stack
-      run: docker compose up -d
     - name: Deploy app to UAT
       env:
         HEROKU_API_KEY: ${{secrets.HEROKU_UAT_API_KEY}}
         HEROKU_APP_NAME: ${{secrets.HEROKU_UAT_APP_NAME}}
       run: |
-        echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
-        docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
         heroku container:login
+        heroku container:push web -a $HEROKU_APP_NAME
         heroku container:release web -a $HEROKU_APP_NAME
   deploy_to_production:
     runs-on: ubuntu-latest
@@ -64,15 +61,12 @@ jobs:
     - uses: actions/checkout@v1
     - run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
     - run: cp example.env .env
-    - name: Build the docker compose stack
-      run: docker compose up -d
     - name: Deploy app to Production
       if: github.ref == 'refs/heads/production'
       env:
         HEROKU_API_KEY: ${{secrets.HEROKU_PRODUCTION_API_KEY}}
         HEROKU_APP_NAME: ${{secrets.HEROKU_PRODUCTION_APP_NAME}}
       run: |
-        echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
-        docker tag $(docker compose images -q backend) registry.heroku.com/$HEROKU_APP_NAME/web
         heroku container:login
+        heroku container:push web -a $HEROKU_APP_NAME
         heroku container:release web -a $HEROKU_APP_NAME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,10 +42,6 @@ jobs:
     - run: cp example.env .env
     - name: Build the docker compose stack
       run: docker compose up -d
-    - name: Check running containers
-      run: docker ps -a
-    - name: Check logs
-      run: docker compose logs backend
     - name: Deploy app to UAT
       env:
         HEROKU_API_KEY: ${{secrets.HEROKU_UAT_API_KEY}}
@@ -70,10 +66,6 @@ jobs:
     - run: cp example.env .env
     - name: Build the docker compose stack
       run: docker compose up -d
-    - name: Check running containers
-      run: docker ps -a
-    - name: Check logs
-      run: docker compose logs backend
     - name: Deploy app to Production
       if: github.ref == 'refs/heads/production'
       env:


### PR DESCRIPTION
This should hopefully resolve the deployment failures we've started seeing, which I think are a result of the latest GHA runners having Docker v29 which uses `containerd` image store by default - we've not had this issue on our other Heroku based apps which are all using the CLI, so I'm guessing that does something different vs using native `docker` commands.

Either way, this aligns us with our other apps which is useful on its own 🤷 