### PR TITLE
fix: update `django`  to address security vulnerability

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -114,14 +114,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.15"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76"},
-    {file = "django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2"},
+    {file = "django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970"},
+    {file = "django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Addresses: 

```
  django@5.2.14 is affected by the following vulnerabilities:
    PYSEC-2026-197: An issue was discovered in Django 5.2 before 5.2.15 and 6.0 before 6.0.6....
    PYSEC-2026-198: An issue was discovered in Django 5.2 before 5.2.15 and 6.0 before 6.0.6....
    PYSEC-2026-199: An issue was discovered in Django 6.0 before 6.0.6 and 5.2 before 5.2.15....
    PYSEC-2026-200: An issue was discovered in Django 6.0 before 6.0.6 and 5.2 before 5.2.15....
    PYSEC-2026-201: An issue was discovered in Django 5.2 before 5.2.15 and 6.0 before 6.0.6....
```