### PR TITLE
CC-2440: fix 'Must be POST' error

### DIFF
--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -456,7 +456,7 @@ function delete_glossurl() {
         // This determines the post action: jQuery.post( url [, data ] [, success ] [, dataType ] )
         $.post(action,
               {'glossurl': glossurl_id})
-              .success(function () {
+              .done(function () {
                 element.remove();
               });
 


### PR DESCRIPTION
[CC-2440 NZSL Signbank: url field removal causes MUST BE POST error](https://ackama.atlassian.net/browse/CC-2440)

The jQuery responsible for removal of a url on a gloss was using the deprecated and removed function `success()` on a `post()` call.

This was causing the anchor tag being clicked on to send a correct `POST` query, after which the jQuery was crashing, allowing the click to bubble back to the anchor and an incorrect `GET` query to be sent. This `GET` query was causing the error. Because the `POST` query was arriving with its payload intact, the url was in fact getting removed.

Code is now updated to use the `done()` function for `post()`.

Note: Technically the anchor should be changed to a button, but this solution works and there are lots of places refactoring and restyling could potentially be performed.
