### PR TITLE
CCSD-5960: Advanced edit whitespace, followup fixes

### DIFF
--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -171,7 +171,7 @@ function configure_edit() {
     function ensure_trimmed(e) {
         // todo: we should try and avoid mutating the element like this
         //   the editable plugin will use it as the value for textareas, which
-        //   are whitespace sensitive, but does not provide a hook for us
+        //   are whitespace sensitive, and provides the 'before' hook for us
         //   to preprocess the value 
         e.target.innerText = e.target.innerText.trim();
     }
@@ -192,7 +192,7 @@ function configure_edit() {
 
 
      $('.edit_text').editable(edit_post_url, {
-         before    : trim_before,
+         before    : ensure_trimmed,
      });
      $('.edit_int').editable(edit_post_url, {
          type      : 'positiveinteger',
@@ -203,21 +203,21 @@ function configure_edit() {
      });
      $('.edit_area').editable(edit_post_url, {
          type      : 'textarea',
-         before    : trim_before,
+         before    : ensure_trimmed,
      });
      $('.edit_area_translations').editable(edit_post_url, {
          type      : 'textarea',
          width     : 400,
          rows      : 3,
          onblur    : 'ignore',
-         before    : trim_before,
+         before    : ensure_trimmed,
      });
      $('.edit_area_notes').editable(edit_post_url, {
          type      : 'textarea',
          width     : 400,
          rows      : 3,
          onblur    : 'ignore',
-         before    : trim_before,
+         before    : ensure_trimmed,
      });
      $('.edit_url').editable(edit_post_url, {
          type      : 'text',

--- a/signbank/static/js/gloss_edit.js
+++ b/signbank/static/js/gloss_edit.js
@@ -169,10 +169,13 @@ $.editable.addInputType('multicheckbox', {
 function configure_edit() {
 
     function ensure_trimmed(e) {
-        // todo: we should try and avoid mutating the element like this
+        // todo: we should try and avoid mutating the DOM element like this
         //   the editable plugin will use it as the value for textareas, which
-        //   are whitespace sensitive, and provides the 'before' hook for us
-        //   to preprocess the value 
+        //   are whitespace sensitive, so we need to trim the value, however
+        //   doing it this way leaves the element permanently changed.
+        //   the editable plugin does not provide us with an on-the-fly hook
+        //   for modifying the incoming value, so for now this is the best we
+        //   can do.
         e.target.innerText = e.target.innerText.trim();
     }
 


### PR DESCRIPTION
[CCSD-5960 NZSL: left-align fields in Signbank](https://ackama.atlassian.net/browse/CCSD-5960)

Entry point for function was not renamed, now fixed.
Also comment text updated.
